### PR TITLE
Fix config.commandLine Conditional & Shorten

### DIFF
--- a/src/components/fxRunner/index.js
+++ b/src/components/fxRunner/index.js
@@ -49,11 +49,9 @@ module.exports = class FXRunner {
      */
     setupVariables(){
         // Prepare extra args
-        let extraArgs;
-        if(typeof this.config.commandLine === 'string' || this.config.commandLine.length){
+        let extraArgs = [];
+        if(typeof this.config.commandLine === 'string' && this.config.commandLine.length){
             extraArgs = parseArgsStringToArgv(this.config.commandLine);
-        }else{
-            extraArgs = [];
         }
 
         // Prepare default args


### PR DESCRIPTION
Fixes the issue with `config.commandLine` being `null` (as discussed on Discord) and gets rid of the unnecessary `else`.