### PR TITLE
Added option to disable in game restart warning chat messages

### DIFF
--- a/src/components/configVault.js
+++ b/src/components/configVault.js
@@ -112,7 +112,8 @@ module.exports = class ConfigVault {
                 healthCheck: {
                     failThreshold: (cfg.monitor.healthCheck)? toDefault(cfg.monitor.healthCheck.failThreshold, null) : null,
                     failLimit: (cfg.monitor.healthCheck)? toDefault(cfg.monitor.healthCheck.failLimit, null) : null,
-                }
+                },
+		disableChatMessages: toDefault(cfg.monitor.disableChatMessages, null)
             };
             out.authenticator = {
                 refreshInterval: toDefault(cfg.authenticator.refreshInterval, null), //not in template
@@ -174,6 +175,7 @@ module.exports = class ConfigVault {
             cfg.monitor.heartBeat.failLimit = parseInt(cfg.monitor.heartBeat.failLimit) || 45;
             cfg.monitor.healthCheck.failThreshold = parseInt(cfg.monitor.healthCheck.failThreshold) || 10;
             cfg.monitor.healthCheck.failLimit = parseInt(cfg.monitor.healthCheck.failLimit) || 300;
+            cfg.monitor.disableChatMessages = (cfg.monitor.disableChatMessages == 'true' || cfg.monitor.disableChatMessages == true);
 
             //Authenticator
             cfg.authenticator.refreshInterval = parseInt(cfg.authenticator.refreshInterval) || 15000; //not in template

--- a/src/components/monitor/index.js
+++ b/src/components/monitor/index.js
@@ -137,7 +137,9 @@ module.exports = class Monitor {
                 );
             }else if(action.messages){
                 globals.discordBot.sendAnnouncement(action.messages.discord);
-                globals.fxRunner.srvCmd(`txaBroadcast "txAdmin" "${action.messages.chat}"`);
+                if(this.config.disableChatMessages == false){
+                    globals.fxRunner.srvCmd(`txaBroadcast "txAdmin" "${action.messages.chat}"`);
+                }
             }
         } catch (error) {}
     }

--- a/src/webroutes/settings/save.js
+++ b/src/webroutes/settings/save.js
@@ -187,14 +187,16 @@ function handleFXServer(ctx) {
 function handleMonitor(ctx) {
     //Sanity check
     if(
-        isUndefined(ctx.request.body.schedule)
+        isUndefined(ctx.request.body.schedule),
+        isUndefined(ctx.request.body.disableChatMessages)
     ){
         return ctx.utils.error(400, 'Invalid Request - missing parameters');
     }
 
     //Prepare body input
     let cfg = {
-        schedule: ctx.request.body.schedule.split(',').map((x) => {return x.trim()})
+        schedule: ctx.request.body.schedule.split(',').map((x) => {return x.trim()}),
+        disableChatMessages: (ctx.request.body.disableChatMessages === 'true')
     }
 
     //Validating times
@@ -218,6 +220,7 @@ function handleMonitor(ctx) {
     //Preparing & saving config
     let newConfig = globals.configVault.getScopedStructure('monitor');
     newConfig.restarterSchedule = validTimes;
+    newConfig.disableChatMessages = cfg.disableChatMessages;
     let saveStatus = globals.configVault.saveProfile('monitor', newConfig);
 
     //Sending output

--- a/web/settings.html
+++ b/web/settings.html
@@ -211,6 +211,20 @@
                             </div>
                         </div>
 
+                        <div class="form-group row">
+                            <label for="frmMonitor-chatMessages" class="col-sm-3 col-form-label">Disable Chat Messages</label>
+                            <div class="col-sm-9">
+                                <label class="c-switch c-switch-label c-switch-pill c-switch-success fix-pill-form">
+                                    <input class="c-switch-input" type="checkbox" id="frmMonitor-chatMessages"
+                                        {{monitor.disableChatMessages|undef}} {{readOnly|isDisabled}}>
+                                    <span class="c-switch-slider" data-checked="On" data-unchecked="Off"></span>
+                                </label>
+                                <span class="form-text text-muted">
+                                    Check this if you want to disable broadcast chat messages in game before each scheduled restart.
+                                </span>
+                            </div>
+                        </div>
+
                         <div class="text-center mt-4">
                             <button class="btn btn-sm btn-primary" type="submit" id="frmMonitor-save" {{readOnly|isDisabled}}>
                                 <i class="icon-check"></i> Save Monitor/Restarter Settings
@@ -402,7 +416,8 @@
     //============================================== Monitor Settings
     $('#frmMonitor-save').click(function () {
         let data = {
-            schedule: $('#frmMonitor-schedule').val().trim()
+            schedule: $('#frmMonitor-schedule').val().trim(),
+            disableChatMessages: ($('#frmMonitor-chatMessages').is(':checked') === true)
         }
         var notify = $.notify({ message: '<p class="text-center">Saving...</p>' }, {});
 


### PR DESCRIPTION
Hello Tabarra,

I know you have a lot of work to do and I wish you good luck.

I personally needed an option to disable in game chat messages before scheduled restarts, and I tought this would be helpful for other txAdmin users.

In this PR I have added an option in _Settings -> Monitor_, just under the restart schedule, to disable in game chat messages:

![image](https://user-images.githubusercontent.com/15368990/82911589-5e8ffb00-9f6c-11ea-9dc7-a2fa0ea0396d.png)

I kept the default behaviour of course and I tested both cases.

Hope you'll accept this pull request.

Good luck again !

Issam.