### PR TITLE
Add txAdmin:shutdown server event.

### DIFF
--- a/scripts/sv_main.lua
+++ b/scripts/sv_main.lua
@@ -34,6 +34,7 @@ CreateThread(function()
     RegisterCommand("txaBroadcast", txaBroadcast, true)
     RegisterCommand("txaSendDM", txaSendDM, true)
     RegisterCommand("txaReportResources", txaReportResources, true)
+    RegisterCommand("txaShutdown", txaShutdown, true)
     CreateThread(function()
         while true do
             HeartBeat()
@@ -270,6 +271,12 @@ function txaReportResources(source, args)
             logError("ReportResources failed with code "..httpCode.." and message: "..resp)
         end
     end, 'POST', json.encode(exData), {['Content-Type']='application/json'})
+end
+
+-- Send a server event prior to shutdown to allow resources to perform last minute saves.
+function txaShutdown(source, args)
+    log('Sending txAdmin:shutdown event.')
+    TriggerEvent('txAdmin:shutdown')
 end
 
 -- Player connecting handler

--- a/scripts/sv_main.lua
+++ b/scripts/sv_main.lua
@@ -34,7 +34,7 @@ CreateThread(function()
     RegisterCommand("txaBroadcast", txaBroadcast, true)
     RegisterCommand("txaSendDM", txaSendDM, true)
     RegisterCommand("txaReportResources", txaReportResources, true)
-    RegisterCommand("txaShutdown", txaShutdown, true)
+    RegisterCommand("txaShuttingDown", txaShuttingDown, true)
     CreateThread(function()
         while true do
             HeartBeat()
@@ -274,7 +274,7 @@ function txaReportResources(source, args)
 end
 
 -- Send a server event prior to shutdown to allow resources to perform last minute saves.
-function txaShutdown(source, args)
+function txaShuttingDown(source, args)
     log('Sending txAdmin:shutdown event.')
     TriggerEvent('txAdmin:shutdown')
 end

--- a/src/components/fxRunner/index.js
+++ b/src/components/fxRunner/index.js
@@ -243,7 +243,7 @@ module.exports = class FXRunner {
     async restartServer(tReason){
         try {
             //Trigger the command to send a server-wide event notifying resources of the pending shutdown.
-            this.srvCmd('txaShutdown');
+            this.srvCmd('txaShuttingDown');
             await sleep(5000);
 
             //If a reason is provided, announce restart on discord, kick all players and wait 750ms
@@ -284,7 +284,7 @@ module.exports = class FXRunner {
     async killServer(tReason){
         try {
             //Trigger the command to send a server-wide event notifying resources of the pending shutdown.
-            this.srvCmd('txaShutdown')
+            this.srvCmd('txaShuttingDown')
             await sleep(5000)
     
             //If a reason is provided, announce restart on discord, kick all players and wait 500ms

--- a/src/components/fxRunner/index.js
+++ b/src/components/fxRunner/index.js
@@ -242,6 +242,10 @@ module.exports = class FXRunner {
      */
     async restartServer(tReason){
         try {
+            //Trigger the command to send a server-wide event notifying resources of the pending shutdown.
+            this.srvCmd('txaShutdown');
+            await sleep(5000);
+
             //If a reason is provided, announce restart on discord, kick all players and wait 750ms
             if(typeof tReason === 'string'){
                 let tOptions = {
@@ -279,6 +283,10 @@ module.exports = class FXRunner {
      */
     async killServer(tReason){
         try {
+            //Trigger the command to send a server-wide event notifying resources of the pending shutdown.
+            this.srvCmd('txaShutdown')
+            await sleep(5000)
+    
             //If a reason is provided, announce restart on discord, kick all players and wait 500ms
             if(typeof tReason === 'string'){
                 let tOptions = {


### PR DESCRIPTION
Added a command to trigger a server event just before restart to allow resources a few seconds to save any necessary data.  This command is automatically triggered 5 seconds prior to the server performing the "quit" command.

-- It could be argued that this is redundant, as the fxserver allows for an event just prior to shutdown.  However, I have found in my experience that that event can be too short for some slightly more complicated saves.  Someone manually restarting a server has an opportunity to manually trigger any saves necessary prior to restart.  I have not been able to find any obvious way to detect txAdmin performing a restart (with the exception of the chat message events,) and thought that this might be helpful to coders who want to ensure that the data they need saved, is in fact saved prior to a restart.