### PR TITLE
Removed the 16 character limit on CitizenFX id

### DIFF
--- a/web/adminManager-editModal.html
+++ b/web/adminManager-editModal.html
@@ -16,7 +16,7 @@
     </label>
     <div class="col-sm-9">
         <div class="input-group">
-            <input type="text" class="form-control" id="modEditAdmin-citizenfxID" maxlength="16"
+            <input type="text" class="form-control" id="modEditAdmin-citizenfxID"
                 autocomplete="off" value="{{it.citizenfx_id}}">
         </div>
         <span class="form-text text-muted">


### PR DESCRIPTION
Sorry but this was so irritating while giving permissions to people with long names on the CitizenFX forum