### PR TITLE
Added a event for txaLogger to include player name on server side

### DIFF
--- a/scripts/sv_logger.js
+++ b/scripts/sv_logger.js
@@ -197,6 +197,14 @@ onNet('txaLogger:CommandExecuted', (data) => {
     }
 });
 
+on('txaLogger:CommandExecutedServer', (data, source) => {
+    try {
+        logger.r(source, 'CommandExecuted', data);
+    } catch (error) {
+        logError(error)
+    }
+});
+
 onNet('txaLogger:DebugMessage', (data) => {
     try {
         logger.r(global.source, 'DebugMessage', data);

--- a/scripts/sv_logger.js
+++ b/scripts/sv_logger.js
@@ -189,17 +189,9 @@ onNet('txaLogger:DeathNotice', (killer, cause) => {
     }
 });
 
-onNet('txaLogger:CommandExecuted', (data) => {
+onNet('txaLogger:CommandExecuted', (data, playerSource) => {
     try {
-        logger.r(global.source, 'CommandExecuted', data);
-    } catch (error) {
-        logError(error)
-    }
-});
-
-on('txaLogger:CommandExecutedServer', (data, source) => {
-    try {
-        logger.r(source, 'CommandExecuted', data);
+        logger.r( (typeof(playerSource) === 'undefined')?global.source:playerSource, 'CommandExecuted', data);
     } catch (error) {
         logError(error)
     }

--- a/scripts/sv_logger.js
+++ b/scripts/sv_logger.js
@@ -191,7 +191,7 @@ onNet('txaLogger:DeathNotice', (killer, cause) => {
 
 onNet('txaLogger:CommandExecuted', (data, playerSource) => {
     try {
-        logger.r( (typeof(playerSource) === 'undefined')?global.source:playerSource, 'CommandExecuted', data);
+        logger.r( (typeof(playerSource) === 'number')?playerSource:global.source, 'CommandExecuted', data);
     } catch (error) {
         logError(error)
     }


### PR DESCRIPTION
Ehem my friend found out that if you had a CommandHandler on the server-side and triggered the event "txaLogger:CommandExecuted", the player name would not be included in the Server Log. By adding a new event called "txaLogger:CommandExecutedServer" and taking the source as an extra argument this problem was resolved.


Example:
server.lua
`
TriggerEvent('txaLogger:CommandExecutedServer', rawCmd, playerSource)
`