### PR TITLE
Fix build script to work on Unix systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "FiveM FXServer Admin - remotely manage your GTA5 FiveM Server",
   "main": "src/index.js",
   "scripts": {
-    "build": "./node_modules/.bin/webpack.cmd --config webpack.config.js --progress"
+    "build": "webpack --config webpack.config.js --progress"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The build fails on Unix systems as the .cmd file doesn't exist, this solution will work on both Windows and Unix.