### PR TITLE
spelling error

### DIFF
--- a/web/settings.html
+++ b/web/settings.html
@@ -337,7 +337,7 @@
                                 </label>
                                 <span class="form-text text-muted">
                                     When enabled, the pending whitelist will be wiped every time txAdmin starts <br>
-                                    This is done to prevent the database to get too big.
+                                    This is done to prevent the database from getting too big.
                                 </span>
                             </div>
                         </div>


### PR DESCRIPTION
In settings page, changed "This is done to prevent the database to get too big." 

To "This is done to prevent the database from getting too big."