### PR TITLE
Add automatic production build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Production build
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Use Node.js ${{ matrix.node-version }}'
+        uses: actions/setup-node@v1
+        with:
+          node-version: '${{ matrix.node-version }}'
+
+      - name: Download all modules
+        run: npm i
+      - name: Build project
+        run: npm run build
+      - name: Compress build output with zip
+        run: (cd ./dist; zip -r ../monitor.zip .)
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./monitor.zip
+          asset_name: monitor.zip
+          asset_content_type: application/zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '${{ matrix.node-version }}'
 
       - name: Download all modules
-        run: npm i
+        run: npm ci
       - name: Build project
         run: npm run build
       - name: Compress build output with zip


### PR DESCRIPTION
Automatic build & deploy. Using and [create-release](https://github.com/actions/create-release) and [upload-release-asset](https://github.com/actions/upload-release-asset). This utilizes github actions virtual machine so you don't have to self host a worker. The average build & deploy time from push is around 30 seconds.