### PR TITLE
Add a broadcast event with the ability to turn off legacy announcement prints

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -25,3 +25,16 @@ AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
     end
 end)
 ```
+
+## txAdmin:events:broadcast
+Called for whenever an announcement is triggered from the admin panel.  
+Arguments:
+- `author`: Username of the person triggering the announcement.  
+- `announcement`: Announcement text
+
+Example usage:
+```lua
+AddEventHandler('txAdmin:events:broadcast', function(eventData)
+    print(("announcement %s: %s"):format(eventData.author, eventData.announcement))
+end)
+```

--- a/src/components/configVault.js
+++ b/src/components/configVault.js
@@ -166,6 +166,7 @@ module.exports = class ConfigVault {
                 autostartDelay: toDefault(cfg.fxRunner.autostartDelay, null), //not in template
                 restartDelay: toDefault(cfg.fxRunner.restartDelay, null), //not in template
                 quiet: toDefault(cfg.fxRunner.quiet, null),
+                disableAnnouncementPrint: toDefault(cfg.fxRunner.disableAnnouncementPrint, null),
             };
         } catch (error) {
             if(GlobalData.verbose) dir(error);
@@ -229,6 +230,7 @@ module.exports = class ConfigVault {
             cfg.fxRunner.autostartDelay = parseInt(cfg.fxRunner.autostartDelay) || 2; //not in template
             cfg.fxRunner.restartDelay = parseInt(cfg.fxRunner.restartDelay) || 1250; //not in templater
             cfg.fxRunner.quiet = (cfg.fxRunner.quiet === 'true' || cfg.fxRunner.quiet === true);
+            cfg.fxRunner.disableAnnouncementPrint = (cfg.fxRunner.disableAnnouncementPrint === 'true' || cfg.fxRunner.disableAnnouncementPrint === true);
             //FXRunner - Converting from old OneSync (build 2751)
             if(isUndefined(cfg.fxRunner.onesync) || cfg.fxRunner.onesync === null){
                 cfg.fxRunner.onesync = 'off'

--- a/src/webroutes/fxserver/commands.js
+++ b/src/webroutes/fxserver/commands.js
@@ -68,10 +68,16 @@ module.exports = async function FXServerCommands(ctx) {
     //==============================================
     }else if(action == 'admin_broadcast'){
         if(!ensurePermission(ctx, 'players.message')) return false;
-        let cmd = formatCommand('txaBroadcast', ctx.session.auth.username, parameter);
+        const config = globals.fxRunner.config
+        const cmd = formatCommand('txaBroadcast', ctx.session.auth.username, parameter);
+        const eventCmd = formatCommand('txaEvent', 'broadcast', JSON.stringify({author: ctx.session.auth.username, announcement: parameter}));
+        globals.fxRunner.srvCmdBuffer(eventCmd);
         ctx.utils.logCommand(cmd);
-        let toResp = await globals.fxRunner.srvCmdBuffer(cmd);
-        return sendAlertOutput(ctx, toResp);
+        if (config.disableAnnouncementPrint !== 'true' && config.disableAnnouncementPrint !== true) {
+            let toResp = await globals.fxRunner.srvCmdBuffer(cmd);
+            return sendAlertOutput(ctx, toResp)
+        }
+        return sendAlertOutput(ctx, cmd)
 
     //==============================================
     }else if(action == 'kick_all'){

--- a/src/webroutes/settings/save.js
+++ b/src/webroutes/settings/save.js
@@ -112,7 +112,8 @@ function handleFXServer(ctx) {
         isUndefined(ctx.request.body.commandLine) ||
         isUndefined(ctx.request.body.onesync) ||
         isUndefined(ctx.request.body.autostart) ||
-        isUndefined(ctx.request.body.quiet)
+        isUndefined(ctx.request.body.quiet) ||
+        isUndefined(ctx.request.body.disableAnnouncementPrint)
     ){
         return ctx.utils.error(400, 'Invalid Request - missing parameters');
     }
@@ -125,6 +126,7 @@ function handleFXServer(ctx) {
         onesync: ctx.request.body.onesync,
         autostart: (ctx.request.body.autostart === 'true'),
         quiet: (ctx.request.body.quiet === 'true'),
+        disableAnnouncementPrint: (ctx.request.body.disableAnnouncementPrint === 'true')
     }
 
     //Validating path spaces
@@ -165,6 +167,7 @@ function handleFXServer(ctx) {
     newConfig.autostart = cfg.autostart;
     newConfig.quiet = cfg.quiet;
     newConfig.commandLine = cfg.commandLine;
+    newConfig.disableAnnouncementPrint = cfg.disableAnnouncementPrint;
     let saveStatus = globals.configVault.saveProfile('fxRunner', newConfig);
 
     //Sending output

--- a/web/settings.html
+++ b/web/settings.html
@@ -194,6 +194,23 @@
                             </div>
                         </div>
 
+                        <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">
+                                Disable Announcement Warnings
+                            </label>
+                            <div class="col-sm-9">
+                                <label class="c-switch c-switch-label c-switch-pill c-switch-success fix-pill-form">
+                                    <input class="c-switch-input" type="checkbox" id="frmFXServer-announcementPrint"
+                                        {{it.fxserver.disableAnnouncementPrint|undef}} {{it.readOnly|isDisabled}}>
+                                    <span class="c-switch-slider" data-checked="On" data-unchecked="Off"></span>
+                                </label>
+                                <span class="form-text text-muted">
+                                    Check this if you want to disable broadcast chat warning messages in game for announcements.<br>
+                                    This is best used if you want to trigger the custom event <code>txAdmin:events:broadcast</code> <a href="https://github.com/tabarra/txAdmin/blob/master/docs/events.md" target="_blank" rel="noopener noreferrer">(docs)</a>
+                                </span>
+                            </div>
+                        </div>
+
                         <div class="text-center mt-4">
                             <button class="btn btn-sm btn-primary" type="submit" id="frmFXServer-save" {{it.readOnly|isDisabled}}>
                                 <i class="icon-check"></i> Save FXServer Settings
@@ -591,7 +608,8 @@
             commandLine: $('#frmFXServer-commandLine').val().trim(),
             onesync: $('#frmFXServer-onesync').val(),
             autostart: $('#frmFXServer-autostart').is(':checked'),
-            quiet: $('#frmFXServer-quiet').is(':checked')
+            quiet: $('#frmFXServer-quiet').is(':checked'),
+            disableAnnouncementPrint: ($('#frmFXServer-announcementPrint').is(':checked') === true),
         }
         if (!data.serverDataPath.length || !data.cfgPath.length) {
             var notify = $.notify({ message: 'The fields with "*" are required.' }, { type: 'warning' });


### PR DESCRIPTION
I added an event for admin broadcasts under `txAdmin:events:broadcast` for custom styling abilities.

I went by most of how the original PR regarding server restarts has been created, but I am uncertain about the location of the toggle as well as pulling in the config in `fxserver/commands.js`. Listening to feedback regarding that, willing to move it.