### PR TITLE
fix(web/players): Fix instances of text overflow on long player names

### DIFF
--- a/web/playerList.html
+++ b/web/playerList.html
@@ -310,8 +310,8 @@
                                     {{@each(it.lastPlayers) => player}}
                                         <!-- FIXME: fix logEntryClickableX and onclickX-->
                                         <div class="list-group-item list-group-item-accent-{{player.color}} logEntry logEntryClickable">
-                                            <div class="d-flex w-100 justify-content-between" onclick="showPlayer('{{player.license}}')"> 
-                                                <strong>{{player.name}}</strong>
+                                            <div class="d-flex w-100 justify-content-between" onclick="showPlayer('{{player.license}}')">
+                                                <strong class="overflow-hidden">{{player.name}}</strong>
                                                 <small>{{player.joined}}</small>
                                             </div>
                                         </div>

--- a/web/public/css/txAdmin.css
+++ b/web/public/css/txAdmin.css
@@ -212,6 +212,12 @@ mark {background-color: #ffeaa7;}
 #modPlayer > .modal-dialog {
     max-width: 620px;
 }
+
+#modPlayerTitle {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 #modPlayer .nav-link > i {
     padding-right: 0.75rem;
 }


### PR DESCRIPTION
# Before & After

![before](https://i.tasoagc.dev/Ta65)
![after](https://i.tasoagc.dev/yaFh)

![before](https://i.tasoagc.dev/s0Uq)
![after](https://i.tasoagc.dev/p1yW)