### PR TITLE
fix(scripts): fix null source on connect handler

### DIFF
--- a/scripts/sv_main.lua
+++ b/scripts/sv_main.lua
@@ -302,6 +302,7 @@ end
 
 -- Player connecting handler
 function handleConnections(name, skr, d)
+    local player = source
     if GetConvar("txAdmin-checkPlayerJoin", "invalid") == "true" then
         d.defer()
         Wait(0)
@@ -310,7 +311,7 @@ function handleConnections(name, skr, d)
         local url = "http://"..apiHost.."/intercom/checkPlayerJoin"
         local exData = {
             txAdminToken = apiToken,
-            identifiers = GetPlayerIdentifiers(source),
+            identifiers = GetPlayerIdentifiers(player),
             name = name
         }
         if #exData.identifiers <= 1 then


### PR DESCRIPTION
This fixes passing a null source to GetPlayerIdentifiers, this occurs because of the yield for a network tick, resetting source to null. This simply localizes the source before the network tick yield.