### PR TITLE
fix(menu): freeze player after teleport until the collision has loaded

### DIFF
--- a/scripts/menu/client/cl_main_page.lua
+++ b/scripts/menu/client/cl_main_page.lua
@@ -172,6 +172,11 @@ RegisterNetEvent('txAdmin:menu:tpToCoords', function(x, y, z)
         if _z ~= nil then z = _z end
     end
     SetPedCoordsKeepVehicle(ped, x, y, z)
+    if not HasCollisionLoadedAroundEntity(ped) then
+        FreezeEntityPosition(ped, true)
+        while not HasCollisionLoadedAroundEntity(ped) do Wait(50) end
+        FreezeEntityPosition(ped, false)
+    end
     DoScreenFadeIn(500)
     SetGameplayCamRelativeHeading(0)
 end)
@@ -193,6 +198,11 @@ RegisterNetEvent('txAdmin:menu:tpToWaypoint', function()
         local _z = FindZForCoords(x, y)
         if _z ~= nil then z = _z end
         SetPedCoordsKeepVehicle(ped, x, y, z)
+        if not HasCollisionLoadedAroundEntity(ped) then
+		    FreezeEntityPosition(ped, true)
+            while not HasCollisionLoadedAroundEntity(ped) do Wait(50) end
+            FreezeEntityPosition(ped, false)
+        end
         DoScreenFadeIn(500)
         SetGameplayCamRelativeHeading(0)
     else

--- a/scripts/menu/client/cl_main_page.lua
+++ b/scripts/menu/client/cl_main_page.lua
@@ -164,6 +164,7 @@ end)
 ---@param z number
 RegisterNetEvent('txAdmin:menu:tpToCoords', function(x, y, z)
     local ped = PlayerPedId()
+    local veh = GetVehiclePedIsIn(ped, false)
     lastTp = GetEntityCoords(ped)
 
     DoScreenFadeOut(500)
@@ -175,9 +176,9 @@ RegisterNetEvent('txAdmin:menu:tpToCoords', function(x, y, z)
     end
     SetPedCoordsKeepVehicle(ped, x, y, z)
     if not HasCollisionLoadedAroundEntity(ped) then
-        FreezeEntityPosition(ped, true)
+        FreezeEntityPosition(veh or ped, true)
         while not HasCollisionLoadedAroundEntity(ped) do Wait(50) end
-        FreezeEntityPosition(ped, false)
+        FreezeEntityPosition(veh or ped, false)
     end
     DoScreenFadeIn(500)
     SetGameplayCamRelativeHeading(0)
@@ -188,6 +189,7 @@ RegisterNetEvent('txAdmin:menu:tpToWaypoint', function()
     local waypoint = GetFirstBlipInfoId(GetWaypointBlipEnumId())
     if waypoint and waypoint > 0 then
         local ped = PlayerPedId()
+        local veh = GetVehiclePedIsIn(ped, false)
         lastTp = GetEntityCoords(ped)
 
         DoScreenFadeOut(500)
@@ -201,9 +203,9 @@ RegisterNetEvent('txAdmin:menu:tpToWaypoint', function()
         if _z ~= nil then z = _z end
         SetPedCoordsKeepVehicle(ped, x, y, z)
         if not HasCollisionLoadedAroundEntity(ped) then
-		    FreezeEntityPosition(ped, true)
+            FreezeEntityPosition(veh or ped, true)
             while not HasCollisionLoadedAroundEntity(ped) do Wait(50) end
-            FreezeEntityPosition(ped, false)
+            FreezeEntityPosition(veh or ped, false)
         end
         DoScreenFadeIn(500)
         SetGameplayCamRelativeHeading(0)


### PR DESCRIPTION
This prevents falling underground if player has slow HDD / low-end PC