### PR TITLE
feat(cd/release-builds): Automatically generate releases on new tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Create Tagged Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    name: "Build Changelog & Release"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      # We fetch to 0 so we can collect the commits
+      # since last update
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Download all modules
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Compress build output with zip
+        run: |
+          cd dist && zip -r ../monitor.zip .
+
+      - name: Create and Upload Release
+        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: false
+          files: monitor.zip


### PR DESCRIPTION
Adds CD that automatically generates changelogs and builds releases with attached artifacts. This is triggered whenever a tag with `v*` is pushed to the repository.

This is a slightly updated version of #263 that cleans up code, reduces actions, and generates an automatic changelog based on commit conventions of previous commits. This has been tested successfully on my fork.

**Testing Examples:**
[Action Run](https://github.com/TasoOneAsia/txAdmin/runs/3258212566?check_suite_focus=true)
[Generated Release with Changelog & Artifact](https://github.com/TasoOneAsia/txAdmin/releases/tag/v4.5.0)