### PR TITLE
feat: Added a Convar check to disable 'txadmin:selfDataReport'

### DIFF
--- a/scripts/cl_main.lua
+++ b/scripts/cl_main.lua
@@ -39,25 +39,29 @@ end)
 
 
 -- Self data reporting thread
-CreateThread(function()
-    local ceil = math.ceil
-    
-    while true do
-        local ped = PlayerPedId()
-        local vehClass = 0
-        local veh = GetVehiclePedIsIn(ped)
-        if veh and veh > 0 then
-            vehClass = GetVehicleClass(veh)
-        end
+if(GetConvar('disableSelfDataReport', 'false') == 'false') then
+    CreateThread(function()
+        local ceil = math.ceil
+        
 
-        if onesyncEnabled then
-            TriggerServerEvent('txAdmin:selfDataReport', vehClass)
-        else
-            local health = ceil(((GetEntityHealth(ped) - 100) / 100) * 100)
-            local coords = GetEntityCoords(ped) or -1
-            TriggerServerEvent('txAdmin:selfDataReport', vehClass, health, coords)
-        end
 
-        Wait(5000)
-    end
-end)
+        while true do
+            local ped = PlayerPedId()
+            local vehClass = 0
+            local veh = GetVehiclePedIsIn(ped)
+            if veh and veh > 0 then
+                vehClass = GetVehicleClass(veh)
+            end
+
+            if onesyncEnabled then
+                TriggerServerEvent('txAdmin:selfDataReport', vehClass)
+            else
+                local health = ceil(((GetEntityHealth(ped) - 100) / 100) * 100)
+                local coords = GetEntityCoords(ped) or -1
+                TriggerServerEvent('txAdmin:selfDataReport', vehClass, health, coords)
+            end
+
+            Wait(5000)
+        end
+    end)
+end


### PR DESCRIPTION
I've added a Convar check to disable the ``txadmin:selfDataReport`` event being sent from the client to the server.
This is so that you can simply disable that event using ``setr disableSelfDataReport true`` if it bothers you.