### PR TITLE
feat(web): show server profile in document title

### DIFF
--- a/src/webroutes/status.js
+++ b/src/webroutes/status.js
@@ -124,7 +124,7 @@ function prepareMetaData() {
     return {
         favicon,
         title: (globals.monitor.currentStatus == 'ONLINE')
-            ? `(${globals.playerController.activePlayers.length}) txAdmin`
-            : 'txAdmin',
+            ? `(${globals.playerController.activePlayers.length}) ${globals.info.serverProfile} | txAdmin`
+            : `${globals.info.serverProfile} | txAdmin`,
     };
 }


### PR DESCRIPTION
May be wise to combine server-name and profile-name in the future for consistency sake & UX. 

**Preview**

![img](https://i.tasoagc.dev/FuEN)

Closes #405