### PR TITLE
feat(menu/player-modal): Allow usernames in txadmin command

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -179,7 +179,7 @@
         "player_modal": {
             "misc": {
                 "error": "An error occurred fetching this users details. The error is shown below:",
-                "target_not_found": "Was unable to find an online player with ID %{targetId}"
+                "target_not_found": "Was unable to find an online player with ID or an username %{target}"
             },
             "tabs": {
                 "actions": "Actions",

--- a/locale/en.json
+++ b/locale/en.json
@@ -179,7 +179,7 @@
         "player_modal": {
             "misc": {
                 "error": "An error occurred fetching this users details. The error is shown below:",
-                "target_not_found": "Was unable to find an online player with ID or an username %{target}"
+                "target_not_found": "Was unable to find an online player with ID or an username of %{target}"
             },
             "tabs": {
                 "actions": "Actions",

--- a/menu/src/MenuWrapper.tsx
+++ b/menu/src/MenuWrapper.tsx
@@ -16,6 +16,7 @@ import { useCheckCredentials } from "./hooks/useCheckCredentials";
 import { PlayerModalProvider } from "./provider/PlayerModalProvider";
 import { txAdminMenuPage, useSetPage } from "./state/page.state";
 import { useListenerForSomething } from "./hooks/useListenerForSomething";
+import { usePlayersFilterIsTemp, useSetPlayerFilter } from "./state/players.state";
 
 debugData(
   [
@@ -30,6 +31,9 @@ debugData(
 const MenuWrapper: React.FC = () => {
   const visible = useIsMenuVisibleValue();
   const serverCtx = useServerCtxValue();
+  const [playersFilterIsTemp, setPlayersFilterIsTemp] = usePlayersFilterIsTemp();
+  const setPlayerFilter = useSetPlayerFilter();
+
   const setPage = useSetPage();
   // These hooks don't ever unmount
   useExitListener();
@@ -39,11 +43,18 @@ const MenuWrapper: React.FC = () => {
   //Change page back to Main when closed
   useEffect(() => {
     if (visible) return;
+
     const changeTimer = setTimeout(() => {
       setPage(txAdminMenuPage.Main);
     }, 750);
+
+    if (playersFilterIsTemp) {
+      setPlayerFilter("");
+      setPlayersFilterIsTemp(false);
+    }
+
     return () => clearInterval(changeTimer);
-  }, [visible]);
+  }, [visible, playersFilterIsTemp]);
 
   const localeSelected = useMemo(() => getLocale(serverCtx.locale), [
     serverCtx.locale,

--- a/menu/src/components/PlayersPage/PlayerPageHeader.tsx
+++ b/menu/src/components/PlayersPage/PlayerPageHeader.tsx
@@ -13,7 +13,8 @@ import {
   PlayerDataSort,
   usePlayersSortBy,
   usePlayersState,
-  useSetPlayerFilter,
+  usePlayersFilter,
+  useSetPlayersFilterIsTemp
 } from "../../state/players.state";
 import { useDebounce } from "../../hooks/useDebouce";
 import { useServerCtxValue } from "../../state/server.state";
@@ -39,9 +40,10 @@ const TextFieldInputs = styled(TextField)({
 
 export const PlayerPageHeader: React.FC = () => {
   const [sortType, setSortType] = usePlayersSortBy();
-  const setPlayerFilter = useSetPlayerFilter();
+  const [playerFilter, setPlayerFilter] = usePlayersFilter();
   const allPlayers = usePlayersState();
   const [searchVal, setSearchVal] = useState("");
+  const setPlayersFilterIsTemp = useSetPlayersFilterIsTemp();
   const serverCtx = useServerCtxValue();
   const t = useTranslate();
 
@@ -54,11 +56,17 @@ export const PlayerPageHeader: React.FC = () => {
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchVal(e.target.value);
+    setPlayersFilterIsTemp(false);
   };
 
   useEffect(() => {
     setPlayerFilter(debouncedInput as string);
   }, [debouncedInput, setPlayerFilter]);
+
+  // Synchronize filter from player state, used for optional args in /tx
+  useEffect(() => {
+    setSearchVal(playerFilter);
+  }, [playerFilter])
 
   return (
     <Box display="flex" justifyContent="space-between">
@@ -69,11 +77,10 @@ export const PlayerPageHeader: React.FC = () => {
         <TypographyPlayerCount>
           {`${allPlayers.length}/${serverCtx.maxClients} ${t(
             "nui_menu.page_players.misc.players"
-          )} - ${
-            serverCtx.oneSync.status
-              ? `OneSync (${serverCtx.oneSync.type})`
-              : `OneSync Off`
-          }`}
+          )} - ${serverCtx.oneSync.status
+            ? `OneSync (${serverCtx.oneSync.type})`
+            : `OneSync Off`
+            }`}
         </TypographyPlayerCount>
       </Box>
       <Box display="flex" alignItems="center" justifyContent="center">

--- a/menu/src/state/players.state.ts
+++ b/menu/src/state/players.state.ts
@@ -55,10 +55,10 @@ const playersState = {
 
       const playerStates: PlayerData[] = filteredValueInput
         ? unfilteredPlayerStates.filter(
-            (player) =>
-              player.username.toLowerCase().includes(formattedInput) ||
-              player.id.toString().includes(formattedInput)
-          )
+          (player) =>
+            player.username.toLowerCase().includes(formattedInput) ||
+            player.id.toString().includes(formattedInput)
+        )
         : unfilteredPlayerStates;
 
       switch (sortType) {
@@ -83,6 +83,11 @@ const playersState = {
     key: "filterPlayerDataInput",
     default: "",
   }),
+  // If true, player data filter will reset on page switch
+  filterPlayerDataIsTemp: atom({
+    key: "filterPlayerDataIsTemp",
+    default: false,
+  }),
 };
 
 export const usePlayersState = () => useRecoilValue(playersState.playerData);
@@ -93,6 +98,9 @@ export const useSetPlayersState = () =>
 export const useSetPlayerFilter = () =>
   useSetRecoilState(playersState.filterPlayerDataInput);
 
+export const useSetPlayersFilterIsTemp = () =>
+  useSetRecoilState(playersState.filterPlayerDataIsTemp);
+
 export const usePlayersSortedValue = () =>
   useRecoilValue(playersState.sortedAndFilteredPlayerData);
 
@@ -101,6 +109,9 @@ export const usePlayersSortBy = () =>
 
 export const usePlayersFilter = () =>
   useRecoilState(playersState.filterPlayerDataInput);
+
+export const usePlayersFilterIsTemp = () =>
+  useRecoilState(playersState.filterPlayerDataIsTemp);
 
 export const useFilteredSortedPlayers = (): PlayerData[] =>
   useRecoilValue(playersState.sortedAndFilteredPlayerData);
@@ -244,7 +255,7 @@ debugData<PlayerData[]>(
   3000
 );
 
-function mockData() {
+function mockData () {
   const randomUsernames = [
     "hamy",
     "taso",

--- a/scripts/menu/client/cl_base.lua
+++ b/scripts/menu/client/cl_base.lua
@@ -22,10 +22,10 @@ local function txadmin(_, args)
   end
 
   if menuIsAccessible then
-    local targetPlayer = args[1] and tonumber(args[1])
     toggleMenuVisibility()
     -- Shortcut to open a specific players profile
-    if isMenuVisible and targetPlayer then
+    if isMenuVisible and #args >= 1 then
+      local targetPlayer = table.concat(args, ' ')
       sendMenuMessage('openPlayerModal', targetPlayer)
     end
   else


### PR DESCRIPTION
/tx or /txadmin will now accept usernames with ids, if multiple clients with similiar names are found it will fill out the search input with the arguments from txadmin command and list all similiar names. Unless the search input is modified it will be cleared when the menu gets closed.