### PR TITLE
feat(menu/actions): Add expiration to ban event data

### DIFF
--- a/src/webroutes/player/actions.js
+++ b/src/webroutes/player/actions.js
@@ -325,6 +325,7 @@ async function handleBan(ctx, sess) {
         reason,
         actionId,
         target: reference,
+        duration
     });
 
     const toResp = await globals.fxRunner.srvCmdBuffer(cmd);

--- a/src/webroutes/player/actions.js
+++ b/src/webroutes/player/actions.js
@@ -325,7 +325,7 @@ async function handleBan(ctx, sess) {
         reason,
         actionId,
         target: reference,
-        duration
+        expiration
     });
 
     const toResp = await globals.fxRunner.srvCmdBuffer(cmd);


### PR DESCRIPTION
Add `duration` to data sent with `txAdmin:events:playerBanned` event.