### PR TITLE
feat(menu): add steam id as admin provider to work with redm

### DIFF
--- a/src/webroutes/adminManager/actions.js
+++ b/src/webroutes/adminManager/actions.js
@@ -125,6 +125,16 @@ async function handleAdd(ctx) {
         };
     }
 
+    //Validate Steam ID
+    let steamData = false;
+    if (steamID.length) {
+        if (!isNaN(parseInt(steamID, 16))) return ctx.send({type: 'danger', message: 'Invalid Steam ID'});
+        steamData = {
+            id: steamID,
+            identifier: `steam:${steamID}`,
+        };
+    }
+
     //Check for privilege escalation
     if (!ctx.session.auth.master && !ctx.session.auth.permissions.includes('all_permissions')) {
         const deniedPerms = permissions.filter((x) => !ctx.session.auth.permissions.includes(x));
@@ -138,7 +148,7 @@ async function handleAdd(ctx) {
 
     //Add admin and give output
     try {
-        await globals.adminVault.addAdmin(name, citizenfxData, discordData, password, permissions);
+        await globals.adminVault.addAdmin(name, citizenfxData, discordData, steamData, password, permissions);
         ctx.utils.logAction(`Adding admin '${name}'.`);
         return ctx.send({type: 'showPassword', password});
     } catch (error) {
@@ -158,6 +168,7 @@ async function handleEdit(ctx) {
         typeof ctx.request.body.name !== 'string'
         || typeof ctx.request.body.citizenfxID !== 'string'
         || typeof ctx.request.body.discordID !== 'string'
+        || typeof ctx.request.body.steamID !== 'string'
         || isUndefined(ctx.request.body.permissions)
     ) {
         return ctx.utils.error(400, 'Invalid Request - missing parameters');
@@ -167,6 +178,7 @@ async function handleEdit(ctx) {
     const name = ctx.request.body.name.trim();
     const citizenfxID = ctx.request.body.citizenfxID.trim();
     const discordID = ctx.request.body.discordID.trim();
+    const steamID = ctx.request.body.steamID.trim();
     const editingSelf = (ctx.session.auth.username.toLowerCase() === name.toLowerCase());
     let permissions;
     if (!editingSelf) {
@@ -221,6 +233,16 @@ async function handleEdit(ctx) {
         };
     }
 
+    //Validate Steam ID
+    let steamData = false;
+    if (steamID.length) {
+        if (!isNaN(parseInt(steamID, 16))) return ctx.send({type: 'danger', message: 'Invalid Steam ID'});
+        steamData = {
+            id: steamID,
+            identifier: `steam:${steamID}`,
+        };
+    }
+
     //Check if admin exists
     const admin = globals.adminVault.getAdminByName(name);
     if (!admin) return ctx.send({type: 'danger', message: 'Admin not found.'});
@@ -243,7 +265,7 @@ async function handleEdit(ctx) {
 
     //Add admin and give output
     try {
-        await globals.adminVault.editAdmin(name, null, citizenfxData, discordData, permissions);
+        await globals.adminVault.editAdmin(name, null, citizenfxData, discordData, steamData, permissions);
         ctx.utils.logAction(`Editing user '${name}'.`);
         return ctx.send({type: 'success', message: 'refresh'});
     } catch (error) {
@@ -325,6 +347,7 @@ async function handleGetModal(ctx, isNewAdmin) {
             username: '',
             citizenfx_id: '',
             discord_id: '',
+            steam_id: '',
             permsGeneral,
             permsMenu,
         };
@@ -356,6 +379,7 @@ async function handleGetModal(ctx, isNewAdmin) {
         username: admin.name,
         citizenfx_id: (admin.providers.citizenfx) ? admin.providers.citizenfx.id : '',
         discord_id: (admin.providers.discord) ? admin.providers.discord.id : '',
+        steam_id: (admin.providers.steam) ? admin.providers.steam.id : '',
         editingSelf: (ctx.session.auth.username.toLowerCase() === name.toLowerCase()),
         permsGeneral,
         permsMenu,

--- a/src/webroutes/adminManager/get.js
+++ b/src/webroutes/adminManager/get.js
@@ -24,6 +24,7 @@ module.exports = async function AdminManagerGet(ctx) {
         return {
             hasCitizenFX: (admin.providers.includes('citizenfx')),
             hasDiscord: (admin.providers.includes('discord')),
+            hasSteam: (admin.providers.includes('steam')),
             name: admin.name,
             perms: perms,
             disableEdit: !ctx.session.auth.master && admin.master,

--- a/web/adminManager/index.html
+++ b/web/adminManager/index.html
@@ -26,6 +26,9 @@
     <symbol id="password-icon" viewBox="0 0 580 580" style="fill: rgb(194, 194, 59);">
         <path d="M463.748,48.251c-64.336-64.336-169.013-64.335-233.349,0.001c-43.945,43.945-59.209,108.706-40.181,167.461 L4.396,401.536c-2.813,2.813-4.395,6.621-4.395,10.606V497c0,8.291,6.709,15,15,15h84.858c3.984,0,7.793-1.582,10.605-4.395 l21.211-21.226c3.237-3.237,4.819-7.778,4.292-12.334l-2.637-22.793l31.582-2.974c7.178-0.674,12.847-6.343,13.521-13.521 l2.974-31.582l22.793,2.651c4.233,0.571,8.496-0.85,11.704-3.691c3.193-2.856,5.024-6.929,5.024-11.206V363h27.422 c3.984,0,7.793-1.582,10.605-4.395l38.467-37.958c58.74,19.043,122.381,4.929,166.326-39.046 C528.084,217.266,528.084,112.587,463.748,48.251z M421.313,154.321c-17.549,17.549-46.084,17.549-63.633,0 s-17.549-46.084,0-63.633s46.084-17.549,63.633,0S438.861,136.772,421.313,154.321z"/>
     </symbol>
+    <symbol id="steam-icon" viewBox="0 0 24 24" style="fill: rgb(0, 0, 0);">
+        <path d="M12 2a10 10 0 0 1 10 10a10 10 0 0 1-10 10c-4.6 0-8.45-3.08-9.64-7.27l3.83 1.58a2.843 2.843 0 0 0 2.78 2.27c1.56 0 2.83-1.27 2.83-2.83v-.13l3.4-2.43h.08c2.08 0 3.77-1.69 3.77-3.77s-1.69-3.77-3.77-3.77s-3.78 1.69-3.78 3.77v.05l-2.37 3.46l-.16-.01c-.59 0-1.14.18-1.59.49L2 11.2C2.43 6.05 6.73 2 12 2M8.28 17.17c.8.33 1.72-.04 2.05-.84c.33-.8-.05-1.71-.83-2.04l-1.28-.53c.49-.18 1.04-.19 1.56.03c.53.21.94.62 1.15 1.15c.22.52.22 1.1 0 1.62c-.43 1.08-1.7 1.6-2.78 1.15c-.5-.21-.88-.59-1.09-1.04l1.22.5m9.52-7.75c0 1.39-1.13 2.52-2.52 2.52a2.52 2.52 0 0 1-2.51-2.52a2.5 2.5 0 0 1 2.51-2.51a2.52 2.52 0 0 1 2.52 2.51m-4.4 0c0 1.04.84 1.89 1.89 1.89c1.04 0 1.88-.85 1.88-1.89s-.84-1.89-1.88-1.89c-1.05 0-1.89.85-1.89 1.89z" />
+    </symbol>
 
     <!-- Reserved for licenses: -->
     <symbol id="fivem-icon" viewBox="0 0 342 430" style="fill: rgb(226, 144, 92);">
@@ -79,6 +82,12 @@
                                         <svg>
                                             <title>Cfx.re Authentication</title>
                                             <use href="#cfxre-icon"></use>
+                                        </svg>
+                                    </i>
+                                    <i class="admin-icon" style="opacity: {{[(admin.hasSteam), '1', '0.09']|ternary}};">
+                                        <svg>
+                                            <title>Steam Authentication</title>
+                                            <use href="#steam-icon"></use>
                                         </svg>
                                     </i>
                                     <i class="admin-icon" style="opacity: {{[(admin.hasDiscord), '1', '0.09']|ternary}};">
@@ -221,6 +230,7 @@
                     $('#modAdmin-name').val(autofill.name);
                     $('#modAdmin-citizenfxID').val(autofill.citizenfxID);
                     $('#modAdmin-discordID').val(autofill.discordID);
+                    $('#modAdmin-steamID').val(autofill.steamID);
                     autofill = false;
                 }
                 $('#modAdmin').modal('show');
@@ -246,6 +256,7 @@
             name: $('#modAdmin-name').val().trim(),
             citizenfxID: $('#modAdmin-citizenfxID').val().trim(),
             discordID: $('#modAdmin-discordID').val().trim(),
+            steamID: $('#modAdmin-steamID').val().trim(),
             permissions: (permissions.length)? permissions : false
         }
         if(formData.name.length < 3) {

--- a/web/adminManager/modal.html
+++ b/web/adminManager/modal.html
@@ -31,6 +31,22 @@
     </div>
 </div>
 
+<!-- Field: Steam -->
+<div class="form-group row">
+    <label for="modAdmin-steamID" class="col-sm-3 col-form-label">
+        Steam ID <br>
+        <small class="text-muted">(optional)</small>
+    </label>
+    <div class="col-sm-9">
+        <div class="input-group">
+            <input type="text" class="form-control" id="modAdmin-steamID" autocomplete="off" value="{{it.steam_id}}">
+        </div>
+        <span class="form-text text-muted">
+            The admin's Steam User ID. Can be found in the Player Modal.
+        </span>
+    </div>
+</div>
+
 <!-- Field: Discord -->
 <div class="form-group row">
     <label for="modAdmin-discordID" class="col-sm-3 col-form-label">


### PR DESCRIPTION
RedM users are not able to open the TxAdmin in-game menu as the identifer for fivem is not provided by redm. 

This adds the functionality to add the admins steam id to the admin manager. 

This makes the TxAdmin in-game menu usable for redm admins.