### PR TITLE
Synced Particle FX when Player Mode is Changed 

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -53,6 +53,10 @@ Convars configured in the settings page should not be set manually.
 - Default: 30
 - Usage: `+setr txAdmin-menuDrunkDuration 120`
 
+**txAdmin-menuPtfxDisable**
+- Description: Determine whether to not play particles whenever an admin's player mode is changed.
+- Default: 0
+- Usage: `+setr txAdmin-menuPtfxDisable 1`
 
 ## Commands
 **tx | txadmin**

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -40,7 +40,7 @@ Convars configured in the settings page should not be set manually.
 
 **txAdmin-menuDebug**
 - Description: Will toggle debug printing on the server and client.
-- Default: false
+- Default: `false`
 - Usage: `+setr txAdmin-menuDebug true`
 
 **txAdmin-menuPlayerIdDistance**
@@ -55,8 +55,8 @@ Convars configured in the settings page should not be set manually.
 
 **txAdmin-menuPtfxDisable**
 - Description: Determine whether to not play particles whenever an admin's player mode is changed.
-- Default: 0
-- Usage: `+setr txAdmin-menuPtfxDisable 1`
+- Default: `false`
+- Usage: `+setr txAdmin-menuPtfxDisable true`
 
 ## Commands
 **tx | txadmin**

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -31,7 +31,8 @@ server_scripts {
     'scripts/menu/server/sv_freeze_player.lua',
     'scripts/menu/server/sv_trollactions.lua',
     'scripts/menu/server/sv_player_modal.lua',
-    'scripts/menu/server/sv_spectate.lua'
+    'scripts/menu/server/sv_spectate.lua',
+    'scripts/menu/server/sv_player_mode.lua'
 }
 
 client_scripts {

--- a/scripts/menu/client/cl_player_mode.lua
+++ b/scripts/menu/client/cl_player_mode.lua
@@ -98,12 +98,69 @@ RegisterCommand('txAdmin:menu:noClipToggle', function()
     end
 end)
 
+local PTFX_ASSET = 'scr_firework_xmas_burst_rgw'
+local PTFX_DICT = 'proj_xmas_firework'
+local LOOP_AMOUNT = 25
+local PTFX_DURATION = 1000
+
+local IS_PTFX_DISABLED = GetConvarInt('txAdmin-menuPtfxDisable', 0) == 1
+
+local function createPlayerModePtfxLoop(tgtPedId)
+    if IS_PTFX_DISABLED then return end
+    CreateThread(function()
+        RequestNamedPtfxAsset(PTFX_DICT)
+        local playerPed = tgtPedId or PlayerPedId()
+
+        -- Wait until it's done loading.
+        while not HasNamedPtfxAssetLoaded(PTFX_DICT) do
+            Wait(0)
+        end
+
+        local particleTbl = {}
+
+        for i=0, LOOP_AMOUNT do
+            UseParticleFxAssetNextCall(PTFX_DICT)
+            local partiResult = StartParticleFxLoopedOnEntity(PTFX_ASSET, playerPed, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.15, false, false, false)
+            particleTbl[#particleTbl + 1] = partiResult
+            Wait(0)
+        end
+
+        Wait(PTFX_DURATION)
+        for _, parti in ipairs(particleTbl) do
+            StopParticleFxLooped(parti, true)
+        end
+    end)
+
+    -- If tgtPed isn't passed, it can be assumed that this was
+    -- local execution and should be synced again. If it is passed,
+    -- then we want to disregard syncing flow and just create the ptfx
+    if tgtPedId then return end
+
+    local players = GetActivePlayers()
+    local playerServerIds = {}
+
+    for _, player in ipairs(players) do
+        playerServerIds[#playerServerIds + 1] = GetPlayerServerId(player)
+    end
+
+    TriggerServerEvent('txsv:syncPtfxEffect', playerServerIds)
+end
+
 -- This will trigger everytime the playerMode in the main menu is changed
 -- it will send the mode
 RegisterNUICallback('playerModeChanged', function(mode, cb)
     debugPrint("player mode requested: " .. (mode or 'nil'))
     TriggerServerEvent('txAdmin:menu:playerModeChanged', mode)
+    createPlayerModePtfxLoop()
     cb({})
+end)
+
+RegisterNetEvent('txcl:syncPtfxEffect', function(tgtSrc)
+    debugPrint('Syncing ptFX for target netId')
+    local tgtPlayer = GetPlayerFromServerId(tgtSrc)
+    local tgtPlayerPed = GetPlayerPed(tgtPlayer)
+    if tgtSrc == 0 then return end
+    createPlayerModePtfxLoop(tgtPlayerPed)
 end)
 
 -- [[ Player mode changed cb event ]]

--- a/scripts/menu/client/cl_player_mode.lua
+++ b/scripts/menu/client/cl_player_mode.lua
@@ -98,8 +98,8 @@ RegisterCommand('txAdmin:menu:noClipToggle', function()
     end
 end)
 
-local PTFX_ASSET = 'scr_firework_xmas_burst_rgw'
-local PTFX_DICT = 'proj_xmas_firework'
+local PTFX_ASSET = 'ent_dst_elec_fire_sp'
+local PTFX_DICT = 'core'
 local LOOP_AMOUNT = 25
 local PTFX_DURATION = 1000
 
@@ -120,7 +120,7 @@ local function createPlayerModePtfxLoop(tgtPedId)
 
         for i=0, LOOP_AMOUNT do
             UseParticleFxAssetNextCall(PTFX_DICT)
-            local partiResult = StartParticleFxLoopedOnEntity(PTFX_ASSET, playerPed, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.15, false, false, false)
+            local partiResult = StartParticleFxLoopedOnEntity(PTFX_ASSET, playerPed, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.5, false, false, false)
             particleTbl[#particleTbl + 1] = partiResult
             Wait(0)
         end

--- a/scripts/menu/client/cl_player_mode.lua
+++ b/scripts/menu/client/cl_player_mode.lua
@@ -83,30 +83,13 @@ local function toggleFreecam(enabled)
 end
 
 
-RegisterCommand('txAdmin:menu:noClipToggle', function()
-    if not DoesPlayerHavePerm(menuPermissions, 'players.playermode') then
-        return sendSnackbarMessage('error', 'nui_menu.misc.general_no_perms', true)
-    end
-
-    debugPrint("NoClip toggled:" .. tostring(not noClipEnabled))
-
-    -- Toggling behavior
-    if noClipEnabled then
-        TriggerServerEvent('txAdmin:menu:playerModeChanged', "none")
-    else
-        TriggerServerEvent('txAdmin:menu:playerModeChanged', "noclip")
-    end
-end)
-
 local PTFX_ASSET = 'ent_dst_elec_fire_sp'
 local PTFX_DICT = 'core'
 local LOOP_AMOUNT = 25
 local PTFX_DURATION = 1000
 
-local IS_PTFX_DISABLED = GetConvarInt('txAdmin-menuPtfxDisable', 0) == 1
-
+-- Applies the particle effect to a ped
 local function createPlayerModePtfxLoop(tgtPedId)
-    if IS_PTFX_DISABLED then return end
     CreateThread(function()
         RequestNamedPtfxAsset(PTFX_DICT)
         local playerPed = tgtPedId or PlayerPedId()
@@ -130,41 +113,48 @@ local function createPlayerModePtfxLoop(tgtPedId)
             StopParticleFxLooped(parti, true)
         end
     end)
-
-    -- If tgtPed isn't passed, it can be assumed that this was
-    -- local execution and should be synced again. If it is passed,
-    -- then we want to disregard syncing flow and just create the ptfx
-    if tgtPedId then return end
-
-    local players = GetActivePlayers()
-    local playerServerIds = {}
-
-    for _, player in ipairs(players) do
-        playerServerIds[#playerServerIds + 1] = GetPlayerServerId(player)
-    end
-
-    TriggerServerEvent('txsv:syncPtfxEffect', playerServerIds)
 end
 
--- This will trigger everytime the playerMode in the main menu is changed
--- it will send the mode
-RegisterNUICallback('playerModeChanged', function(mode, cb)
-    debugPrint("player mode requested: " .. (mode or 'nil'))
-    TriggerServerEvent('txAdmin:menu:playerModeChanged', mode)
-    createPlayerModePtfxLoop()
-    cb({})
-end)
-
 RegisterNetEvent('txcl:syncPtfxEffect', function(tgtSrc)
-    debugPrint('Syncing ptFX for target netId')
+    debugPrint('Syncing particle effect for target netId')
     local tgtPlayer = GetPlayerFromServerId(tgtSrc)
     local tgtPlayerPed = GetPlayerPed(tgtPlayer)
     if tgtSrc == 0 then return end
     createPlayerModePtfxLoop(tgtPlayerPed)
 end)
 
+-- Ask server for playermode change and sends nearby playerlist
+local function askChangePlayerMode(mode)
+    debugPrint("Requesting player mode change to " .. mode)
+
+    -- get nearby players to receive the ptfx sync event
+    local players = GetActivePlayers()
+    local nearbyPlayers = {}
+    for _, player in ipairs(players) do
+        nearbyPlayers[#nearbyPlayers + 1] = GetPlayerServerId(player)
+    end
+
+    TriggerServerEvent('txAdmin:menu:playerModeChanged', mode, nearbyPlayers)
+end
+
+-- NoClip toggle keybind
+RegisterCommand('txAdmin:menu:noClipToggle', function()
+    if not menuIsAccessible then return end
+    if not DoesPlayerHavePerm(menuPermissions, 'players.playermode') then
+        return sendSnackbarMessage('error', 'nui_menu.misc.general_no_perms', true)
+    end
+    askChangePlayerMode(noClipEnabled and 'none' or 'noclip')
+end)
+
+-- Menu callback to change the player mode
+RegisterNUICallback('playerModeChanged', function(mode, cb)
+    askChangePlayerMode(mode)
+    cb({})
+end)
+
 -- [[ Player mode changed cb event ]]
 RegisterNetEvent('txAdmin:menu:playerModeChanged', function(mode)
+    createPlayerModePtfxLoop()
     if mode == 'godmode' then
         toggleFreecam(false)
         toggleGodMode(true)

--- a/scripts/menu/client/cl_spectate.lua
+++ b/scripts/menu/client/cl_spectate.lua
@@ -37,27 +37,27 @@ local function createScaleformThread()
         end
         PushScaleformMovieFunction(scaleform, "CLEAR_ALL")
         PopScaleformMovieFunctionVoid()
-    
+
         PushScaleformMovieFunction(scaleform, "SET_CLEAR_SPACE")
         PushScaleformMovieFunctionParameterInt(200)
         PopScaleformMovieFunctionVoid()
-    
+
         PushScaleformMovieFunction(scaleform, "SET_DATA_SLOT")
         PushScaleformMovieFunctionParameterInt(1)
         InstructionalButton(GetControlInstructionalButton(1, 194), "Exit Spectate Mode")
         PopScaleformMovieFunctionVoid()
-    
-    
+
+
         PushScaleformMovieFunction(scaleform, "DRAW_INSTRUCTIONAL_BUTTONS")
         PopScaleformMovieFunctionVoid()
-    
+
         PushScaleformMovieFunction(scaleform, "SET_BACKGROUND_COLOUR")
         PushScaleformMovieFunctionParameterInt(0)
         PushScaleformMovieFunctionParameterInt(0)
         PushScaleformMovieFunctionParameterInt(0)
         PushScaleformMovieFunctionParameterInt(80)
         PopScaleformMovieFunctionVoid()
-    
+
         while isSpectateEnabled do
             DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
             Wait(0)
@@ -94,6 +94,7 @@ end
 local function preparePlayerForSpec(bool)
     local playerPed = PlayerPedId()
     FreezeEntityPosition(playerPed, bool)
+    SetEntityVisible(playerPed, not bool, 0)
 end
 
 local function createSpectatorTeleportThread()
@@ -101,7 +102,7 @@ local function createSpectatorTeleportThread()
     CreateThread(function()
         while isSpectateEnabled do
             Wait(500)
-            
+
             -- Check if ped still exists
             if not DoesEntityExist(storedTargetPed) then
                 local _ped = GetPlayerPed(storedTargetPlayerId)
@@ -117,7 +118,7 @@ local function createSpectatorTeleportThread()
                     break
                 end
             end
-            
+
             -- Update Teleport
             local newSpectateCoords = calculateSpectatorCoords(GetEntityCoords(storedTargetPed))
             SetEntityCoords(PlayerPedId(), newSpectateCoords.x, newSpectateCoords.y, newSpectateCoords.z, 0, 0, 0, false)

--- a/scripts/menu/server/sv_main_page.lua
+++ b/scripts/menu/server/sv_main_page.lua
@@ -148,20 +148,6 @@ RegisterNetEvent('txAdmin:menu:healAllPlayers', function()
   end
 end)
 
-RegisterNetEvent('txAdmin:menu:playerModeChanged', function(mode)
-  local src = source
-  if mode ~= 'godmode' and mode ~= 'noclip' and mode ~= 'none' then
-    debugPrint("Invalid player mode requested by " .. GetPlayerName(src) .. " (mode: " .. (mode or 'nil'))
-    return
-  end
-
-  local allow = PlayerHasTxPermission(src, 'players.playermode')
-  TriggerEvent("txaLogger:menuEvent", src, "playerModeChanged", allow, mode)
-  if allow then
-    TriggerClientEvent('txAdmin:menu:playerModeChanged', src, mode)
-  end
-end)
-
 RegisterNetEvent('txAdmin:menu:healMyself', function()
   local src = source
   local allow = PlayerHasTxPermission(src, 'players.heal')

--- a/scripts/menu/server/sv_player_mode.lua
+++ b/scripts/menu/server/sv_player_mode.lua
@@ -3,7 +3,9 @@ if GetConvar('txAdminServerMode', 'false') ~= 'true' then
   return
 end
 
-RegisterNetEvent('txAdmin:menu:playerModeChanged', function(mode)
+local IS_PTFX_DISABLED = (GetConvar('txAdmin-menuPtfxDisable', 'false') == 'true')
+
+RegisterNetEvent('txAdmin:menu:playerModeChanged', function(mode, nearbyPlayers)
   local src = source
   if mode ~= 'godmode' and mode ~= 'noclip' and mode ~= 'none' then
     debugPrint("Invalid player mode requested by " .. GetPlayerName(src) .. " (mode: " .. (mode or 'nil'))
@@ -14,21 +16,9 @@ RegisterNetEvent('txAdmin:menu:playerModeChanged', function(mode)
   TriggerEvent("txaLogger:menuEvent", src, "playerModeChanged", allow, mode)
   if allow then
     TriggerClientEvent('txAdmin:menu:playerModeChanged', src, mode)
-  end
-end)
 
-RegisterNetEvent('txsv:syncPtfxEffect', function(playersToTgt)
-  local src = source
-  -- debugPrint('Syncing ptfx change for following table')
-  -- debugPrint(json.encode(playersToTgt))
-  -- We need to make sure source is allowed to change player modes
-  -- otherwise any client could call this event and have ptfx replicated
-  -- upon clients nearby
-  local allow = PlayerHasTxPermission(src, 'players.playermode')
-  if allow then
-    for _, v in ipairs(playersToTgt) do
-      -- Make sure not to trigger the event on the calling clients table
-      if v ~= src then
+    if not IS_PTFX_DISABLED then
+      for _, v in ipairs(nearbyPlayers) do
         TriggerClientEvent('txcl:syncPtfxEffect', v, src)
       end
     end

--- a/scripts/menu/server/sv_player_mode.lua
+++ b/scripts/menu/server/sv_player_mode.lua
@@ -1,0 +1,36 @@
+--Check Environment
+if GetConvar('txAdminServerMode', 'false') ~= 'true' then
+  return
+end
+
+RegisterNetEvent('txAdmin:menu:playerModeChanged', function(mode)
+  local src = source
+  if mode ~= 'godmode' and mode ~= 'noclip' and mode ~= 'none' then
+    debugPrint("Invalid player mode requested by " .. GetPlayerName(src) .. " (mode: " .. (mode or 'nil'))
+    return
+  end
+
+  local allow = PlayerHasTxPermission(src, 'players.playermode')
+  TriggerEvent("txaLogger:menuEvent", src, "playerModeChanged", allow, mode)
+  if allow then
+    TriggerClientEvent('txAdmin:menu:playerModeChanged', src, mode)
+  end
+end)
+
+RegisterNetEvent('txsv:syncPtfxEffect', function(playersToTgt)
+  local src = source
+  -- debugPrint('Syncing ptfx change for following table')
+  -- debugPrint(json.encode(playersToTgt))
+  -- We need to make sure source is allowed to change player modes
+  -- otherwise any client could call this event and have ptfx replicated
+  -- upon clients nearby
+  local allow = PlayerHasTxPermission(src, 'players.playermode')
+  if allow then
+    for _, v in ipairs(playersToTgt) do
+      -- Make sure not to trigger the event on the calling clients table
+      if v ~= src then
+        TriggerClientEvent('txcl:syncPtfxEffect', v, src)
+      end
+    end
+  end
+end)


### PR DESCRIPTION
Specific particle FX is up to consideration. But this allows for dispatching a synced particle FX upon changing of player mode per internal discussion.

[Preview](https://i.tasoagc.dev/tYwT.gif)