### PR TITLE
feat(settings): added option to disable menu particle effects

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -56,7 +56,7 @@ Convars configured in the settings page should not be set manually.
 **txAdmin-menuPtfxDisable**
 - Description: Determine whether to not play particles effects whenever an admin's player mode is changed.
 - Default: `false`
-- Usage: `+set txAdmin-menuPtfxDisable true`
+- Usage: `+setr txAdmin-menuPtfxDisable true`
 
 ## Commands
 **tx | txadmin**

--- a/scripts/cl_main.lua
+++ b/scripts/cl_main.lua
@@ -108,6 +108,7 @@ CreateThread(function()
     --Menu convars
     TriggerEvent('chat:removeSuggestion', '/txAdmin-menuEnabled')
     TriggerEvent('chat:removeSuggestion', '/txAdmin-menuAlignRight')
+    TriggerEvent('chat:removeSuggestion', '/txAdmin-menuPtfxDisable')
     TriggerEvent('chat:removeSuggestion', '/txAdmin-menuPageKey')
     TriggerEvent('chat:removeSuggestion', '/txAdmin-menuDebug')
     TriggerEvent('chat:removeSuggestion', '/txAdmin-playerIdDistance')

--- a/scripts/menu/client/cl_player_mode.lua
+++ b/scripts/menu/client/cl_player_mode.lua
@@ -7,6 +7,7 @@ if (GetConvar('txAdmin-menuEnabled', 'false') ~= 'true') then
 end
 
 local noClipEnabled = false
+local IS_PTFX_DISABLED = (GetConvar('txAdmin-menuPtfxDisable', 'false') == 'true')
 
 local function toggleGodMode(enabled)
     if enabled then
@@ -90,6 +91,9 @@ local PTFX_DURATION = 1000
 
 -- Applies the particle effect to a ped
 local function createPlayerModePtfxLoop(tgtPedId)
+    -- Don't show particles if disabled
+    if IS_PTFX_DISABLED then return end
+	
     CreateThread(function()
         RequestNamedPtfxAsset(PTFX_DICT)
         local playerPed = tgtPedId or PlayerPedId()

--- a/src/components/configVault.js
+++ b/src/components/configVault.js
@@ -116,6 +116,7 @@ module.exports = class ConfigVault {
                 forceFXServerPort: toDefault(cfg.global.forceFXServerPort, null), //not in template
                 menuEnabled: toDefault(cfg.global.menuEnabled, true),
                 menuAlignRight: toDefault(cfg.global.menuAlignRight, false),
+                menuPtfxDisable: toDefault(cfg.global.menuPtfxDisable, false),
                 menuPageKey: toDefault(cfg.global.menuPageKey, 'Tab'),
             };
             out.logger = toDefault(cfg.logger, {}); //not in template
@@ -188,6 +189,7 @@ module.exports = class ConfigVault {
             cfg.global.language = cfg.global.language || 'en'; //TODO: move to GlobalData
             cfg.global.menuEnabled = (cfg.global.menuEnabled === 'true' || cfg.global.menuEnabled === true);
             cfg.global.menuAlignRight = (cfg.global.menuAlignRight === 'true' || cfg.global.menuAlignRight === true);
+            cfg.global.menuPtfxDisable = (cfg.global.menuPtfxDisable === 'true' || cfg.global.menuPtfxDisable === true);
             cfg.global.menuPageKey = cfg.global.menuPageKey || 'Tab';
 
             //Logger - NOTE: this one default's i'm doing directly into the class

--- a/src/components/fxRunner/index.js
+++ b/src/components/fxRunner/index.js
@@ -33,6 +33,7 @@ const getMutableConvars = (isCmdLine = false) => {
         [`${p}setr`, 'txAdmin-verbose', GlobalData.verbose],
         [`${p}set`, 'txAdmin-checkPlayerJoin', checkPlayerJoin],
         [`${p}set`, 'txAdmin-menuAlignRight', globals.config.menuAlignRight],
+        [`${p}setr`, 'txAdmin-menuPtfxDisable', globals.config.menuPtfxDisable],
         [`${p}set`, 'txAdmin-menuPageKey', globals.config.menuPageKey],
     ];
 };

--- a/src/webroutes/settings/save.js
+++ b/src/webroutes/settings/save.js
@@ -372,6 +372,7 @@ function handleMenu(ctx) {
     if (
         isUndefined(ctx.request.body.menuEnabled)
         || isUndefined(ctx.request.body.menuAlignRight)
+        || isUndefined(ctx.request.body.menuPtfxDisable)
         || isUndefined(ctx.request.body.menuPageKey)
     ) {
         return ctx.utils.error(400, 'Invalid Request - missing parameters');
@@ -381,6 +382,7 @@ function handleMenu(ctx) {
     const cfg = {
         menuEnabled: (ctx.request.body.menuEnabled === 'true'),
         menuAlignRight: (ctx.request.body.menuAlignRight === 'true'),
+        menuPtfxDisable: (ctx.request.body.menuPtfxDisable === 'true'),
         menuPageKey: ctx.request.body.menuPageKey.trim(),
     };
 
@@ -388,6 +390,7 @@ function handleMenu(ctx) {
     const newConfig = globals.configVault.getScopedStructure('global');
     newConfig.menuEnabled = cfg.menuEnabled;
     newConfig.menuAlignRight = cfg.menuAlignRight;
+    newConfig.menuPtfxDisable = cfg.menuPtfxDisable;
     newConfig.menuPageKey = cfg.menuPageKey;
     const saveStatus = globals.configVault.saveProfile('global', newConfig);
 

--- a/web/settings.html
+++ b/web/settings.html
@@ -514,6 +514,20 @@
                         </div>
 
                         <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Disable Particles</label>
+                            <div class="col-sm-9">
+                                <label class="c-switch c-switch-label c-switch-pill c-switch-success fix-pill-form">
+                                    <input class="c-switch-input" type="checkbox" id="frmMenu-disableMenuPtfx"
+                                        {{it.global.menuPtfxDisable|undef}} {{it.readOnly|isDisabled}}>
+                                    <span class="c-switch-slider" data-checked="Yes" data-unchecked="No"></span>
+                                </label>
+                                <span class="form-text text-muted">
+                                    When enabled, the menu will not add particle effects to menu actions.
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
                             <label for="frmMenu-pageKey" class="col-sm-3 col-form-label">Page Switch Key</label>
                             <div class="col-sm-9">
                                 <input type="text" class="form-control" id="frmMenu-pageKey"


### PR DESCRIPTION
Didn't like the effects when entering no-clip, so I added the option to disable it, using the already existing Convar