### PR TITLE
fix: common "Unable" typo

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ When executing txAdmin, it might show you some errors. Example of an [error](htt
 If you get `cannot read file`, it means the admin file `txData/admins.json` doesn't exist or txAdmin doesn't have permission to read it.  
 Any other error message means you somehow broke the admins file, delete it and restart txAdmin to generate a new one.
 
-### [txAdmin:ConfigVault] Error: Unnable to load configuration file `txData/<profile>/config.json`
+### [txAdmin:ConfigVault] Error: Unable to load configuration file `txData/<profile>/config.json`
 The selected profile (or `default`) cannot be loaded due to permission issues (eg file owned by the root account), or due to broken JSON.
 
 ## Problems starting the server

--- a/src/components/configVault.js
+++ b/src/components/configVault.js
@@ -71,7 +71,7 @@ module.exports = class ConfigVault {
         try {
             rawFile = fs.readFileSync(this.configFilePath, 'utf8');
         } catch (error) {
-            throw new Error(`Unnable to load configuration file '${this.configFilePath}'. (cannot read file, please read the documentation)\nOriginal error: ${error.message}`);
+            throw new Error(`Unable to load configuration file '${this.configFilePath}'. (cannot read file, please read the documentation)\nOriginal error: ${error.message}`);
         }
 
         //Try to parse config file
@@ -80,7 +80,7 @@ module.exports = class ConfigVault {
             cfgData = JSON.parse(rawFile);
         } catch (error) {
             if (rawFile.includes('\\')) logError(`Note: your 'txData/${this.serverProfile}/config.json' file contains '\\', make sure all your paths use only '/'.`);
-            throw new Error(`Unnable to load configuration file '${this.configFilePath}'. \nOriginal error: ${error.message}`);
+            throw new Error(`Unable to load configuration file '${this.configFilePath}'. \nOriginal error: ${error.message}`);
         }
 
         return cfgData;

--- a/src/components/statsCollector/index.js
+++ b/src/components/statsCollector/index.js
@@ -60,7 +60,7 @@ module.exports = class StatsCollector {
                 await fs.writeFile(this.hardConfigs.heatmapDataFile, '[]');
                 this.perfSeries = [];
             } catch (error) {
-                logError(`Unnable to create stats_heatmapData_v1 with error: ${error.message}`);
+                logError(`Unable to create stats_heatmapData_v1 with error: ${error.message}`);
                 process.exit();
             }
         };

--- a/src/components/statsCollector/timeSeries.js
+++ b/src/components/statsCollector/timeSeries.js
@@ -33,7 +33,7 @@ module.exports = class TimeSeries {
                 fs.writeFileSync(file, '[]');
                 rawFile = '[]';
             } catch (error) {
-                throw new Error('Unnable to create timeseries file.');
+                throw new Error('Unable to create timeseries file.');
             }
         }
 


### PR DESCRIPTION
Fixes common typo where "Unable" is written as "Unnable", which caused a subset of users (me) to briefly experience a burst of uncontrollable anger.