### PR TITLE
fix(helper): fix not being able to define multiple endpoints

### DIFF
--- a/src/extras/helpers.js
+++ b/src/extras/helpers.js
@@ -198,9 +198,6 @@ function getFXServerPort(rawCfgFile) {
     if (!oneUDPEndpoint) throw new Error('You MUST have at least one <code>endpoint_add_udp</code> in your config');
 
     const firstPort = endpoints[0].port;
-    endpoints.forEach((m) => {
-        if (m.port !== firstPort) throw new Error('All <code>endpoint_add_*</code> MUST have the same port');
-    });
 
     //Check if the port is valid
     if (firstPort >= 40120 && firstPort <= 40150) {


### PR DESCRIPTION
Not all endpoints _have_ to have the same endpoint, you can have however many endpoints you want for internal usage like defining port 8000 and only letting specific server access it for cache/proxy.