### PR TITLE
feat(core): initial support for custom launch scripts

### DIFF
--- a/src/components/configVault.js
+++ b/src/components/configVault.js
@@ -160,6 +160,7 @@ module.exports = class ConfigVault {
                 autostart: toDefault(cfg.fxRunner.autostart, null),
                 restartDelay: toDefault(cfg.fxRunner.restartDelay, null), //not in template
                 quiet: toDefault(cfg.fxRunner.quiet, null),
+                preLaunchScript: toDefault(cfg.fxRunner.preLaunchScript, null),
             };
 
             //Migrations
@@ -231,6 +232,7 @@ module.exports = class ConfigVault {
             cfg.fxRunner.autostart = (cfg.fxRunner.autostart === 'true' || cfg.fxRunner.autostart === true);
             cfg.fxRunner.restartDelay = parseInt(cfg.fxRunner.restartDelay) || 1250; //not in templater
             cfg.fxRunner.quiet = (cfg.fxRunner.quiet === 'true' || cfg.fxRunner.quiet === true);
+            cfg.fxRunner.preLaunchScript = (cfg.fxRunner.preLaunchScript || false)
         } catch (error) {
             if (GlobalData.verbose) dir(error);
             throw new Error(`Malformed configuration file! Make sure your txAdmin is updated.\nOriginal error: ${error.message}`);
@@ -293,6 +295,7 @@ module.exports = class ConfigVault {
             webServer: cfg.webServer,
             discordBot: cfg.discordBot,
             fxRunner: cfg.fxRunner,
+            scripts: cfg.scripts,
         });
     }
 

--- a/src/components/fxRunner/index.js
+++ b/src/components/fxRunner/index.js
@@ -1,6 +1,6 @@
 //Requires
 const modulename = 'FXRunner';
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 const path = require('path');
 const chalk = require('chalk');
 const sleep = require('util').promisify((a, f) => setTimeout(f, a));
@@ -203,6 +203,13 @@ module.exports = class FXRunner {
         if (announce === 'true' || announce === true) {
             let discordMessage = globals.translator.t('server_actions.spawning_discord', {servername: globals.config.serverName});
             globals.discordBot.sendAnnouncement(discordMessage);
+        }
+
+        // Pre-launch
+        if (this.config.preLaunchScript) {
+            logOk("Running pre-launch script: " + this.config.preLaunchScript)
+            const output = spawnSync(this.config.preLaunchScript)
+            logOk(output.stdout)
         }
 
         //Starting server

--- a/src/webroutes/settings/save.js
+++ b/src/webroutes/settings/save.js
@@ -42,6 +42,8 @@ module.exports = async function SettingsSave(ctx) {
         return handleDiscord(ctx);
     } else if (scope == 'menu') {
         return handleMenu(ctx);
+    } else if (scope == 'scripts') {
+        return handleScripts(ctx);
     } else {
         return ctx.send({
             type: 'danger',
@@ -399,6 +401,33 @@ function handleMenu(ctx) {
         return ctx.send({type: 'success', message: '<strong>Menu configuration saved!<br>You need to restart the server for the changes to take effect.</strong>'});
     } else {
         logWarn(`[${ctx.session.auth.username}] Error changing menu settings.`);
+        return ctx.send({type: 'danger', message: '<strong>Error saving the configuration file.</strong>'});
+    }
+}
+
+//================================================================
+/**
+ * Handle Script settings
+ * @param {object} ctx
+ */
+function handleScripts(ctx) {
+    //Prepare body input
+    let cfg = {
+        preLaunchScript: ctx.request.body.preLaunchScript?.trim(),
+    };
+
+    //Preparing & saving config
+    let newConfig = globals.configVault.getScopedStructure('fxRunner');
+    newConfig.preLaunchScript = cfg.preLaunchScript;
+    let saveStatus = globals.configVault.saveProfile('fxRunner', newConfig);
+
+    //Sending output
+    if (saveStatus) {
+        globals.fxRunner.refreshConfig();
+        ctx.utils.logAction('Changing script settings.');
+        return ctx.send({type: 'success', message: '<strong>FXServer script configuration saved!<br>You need to restart the server for the changes to take effect.</strong>'});
+    } else {
+        logWarn(`[${ctx.session.auth.username}] Error changing script settings.`);
         return ctx.send({type: 'danger', message: '<strong>Error saving the configuration file.</strong>'});
     }
 }

--- a/web/settings.html
+++ b/web/settings.html
@@ -36,6 +36,9 @@
                     <li class="nav-item">
                         <a class="nav-item nav-link {{it.activeTab=='menu'|isActive}}" id="nav-menu-tab" data-toggle="tab" href="#nav-menu" role="tab" aria-controls="nav-menu" aria-selected="true">Menu</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-item nav-link {{it.activeTab=='scripts'|isActive}}" id="nav-scripts-tab" data-toggle="tab" href="#nav-scripts" role="tab" aria-controls="nav-scripts" aria-selected="true">Scripts</a>
+                    </li>
                 </ul>
             </div>
 
@@ -494,6 +497,30 @@
                     </div>
                     <!-- /Menu Tab -->
 
+                    <!-- Scripts Tab -->
+                    <div class="tab-pane fade {{it.activeTab=='scripts'|isActive|tShow}}" id="nav-scripts" role="tabpanel"
+                        aria-labelledby="nav-scripts-tab">
+                        <div class="form-group row">
+                            <label for="frmScripts-preLaunchScript" class="col-sm-3 col-form-label">
+                                Pre-Launch Script
+                                <span class="text-danger">*</span>
+                            </label>
+                            <div class="col-sm-9">
+                                <input type="text" class="form-control" id="frmScripts-preLaunchScript"
+                                    value="{{it.fxserver.preLaunchScript|undef}}" maxlength="256" placeholder="path/to/script.bat" {{it.readOnly|isDisabled}}>
+                                <span class="form-text text-muted">
+                                    A script to run before the server is launched
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="text-center mt-4">
+                            <button class="btn btn-sm btn-primary" type="submit" id="frmScripts-save" {{it.readOnly|isDisabled}}>
+                                <i class="icon-check"></i> Save Global Settings
+                            </button>
+                        </div>
+                    </div>
+                    <!-- /Scripts Tab -->
                 </div>
             </div>
 
@@ -732,6 +759,31 @@
         txAdminAPI({
             type: "POST",
             url: '/settings/save/menu',
+            data: data,
+            dataType: 'json',
+            success: function (data) {
+                notify.update('progress', 0);
+                notify.update('type', data.type);
+                notify.update('message', data.message);
+            },
+            error: function (xmlhttprequest, textstatus, message) {
+                notify.update('progress', 0);
+                notify.update('type', 'danger');
+                notify.update('message', message);
+            }
+        });
+    });
+
+    //============================================== Scripts Settings
+    $('#frmScripts-save').click(function () {
+        let data = {
+            preLaunchScript: $('#frmScripts-preLaunchScript').val().trim()
+        };
+        const notify = $.notify({ message: '<p class="text-center">Saving...</p>' }, {});
+
+        txAdminAPI({
+            type: "POST",
+            url: '/settings/save/scripts',
             data: data,
             dataType: 'json',
             success: function (data) {


### PR DESCRIPTION
Hi,

I found a use case to have support to run a "script" such as a bat file before the server is launched. This could be used for things such as building a node project, or pulling a git repo.

This is by no means ready, however I wanted to collect some feedback, comments and concerns (especially regarding security) before I continued further.

My basic todo list is
- Better error handling, right now the server fails to launch if the pre-launch fails
- Other scripts such as post-launch and potentially custom scripts
- Permissions for configuring these settings / running custom scripts
- Being able to specify the directory script will run in (or defaulting to the base directory)

If you believe this is feasible, I am happy to flesh this out further. Feel free to reach out on here or discord if you would prefer.