### PR TITLE
feat(menu/announce): add positioning convar

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -58,6 +58,12 @@ Convars configured in the settings page should not be set manually.
 - Default: `false`
 - Usage: `+set txAdmin-menuPtfxDisable true`
 
+**txAdmin-announce**
+- Description: Determines the location of the txAdmin announcement notification. This **must** use one of the following valid 
+positions, `top-center`, `top-left`, `top-right`, `bottom-center`, `bottom-left`, `bottom-right`.
+- Default: `top-center`
+- Usage: `+set txAdmin-announceNotiPos top-right`
+
 ## Commands
 **tx | txadmin**
 - Description: Will toggle the in-game menu. This command has an optional argument of a player id that will quickly open up the target player's info modal.

--- a/menu/src/hooks/useHudListenersService.tsx
+++ b/menu/src/hooks/useHudListenersService.tsx
@@ -14,6 +14,7 @@ import {
 import { usePlayerModalContext } from "../provider/PlayerModalProvider";
 import { useSetAssociatedPlayer } from "../state/playerDetails.state";
 import { txAdminMenuPage, useSetPage } from "../state/page.state";
+import { useAnnounceNotiPosValue } from "../state/server.state";
 
 type SnackbarAlertSeverities = "success" | "error" | "warning" | "info";
 
@@ -41,7 +42,7 @@ const AnnounceMessage: React.FC<AnnounceMessageProps> = ({
   title,
   message,
 }) => (
-  <Box maxWidth={400} style={{fontSize: "large"}}>
+  <Box maxWidth={400} style={{ fontSize: "large" }}>
     <Typography style={{ fontWeight: "bold" }}>{title}</Typography>
     {message}
   </Box>
@@ -68,6 +69,7 @@ export const useHudListenersService = () => {
   const setPlayerFilter = useSetPlayerFilter();
   const setPlayersFilterIsTemp = useSetPlayersFilterIsTemp();
   const setPage = useSetPage();
+  const notiPos = useAnnounceNotiPosValue();
 
   const snackFormat = (m) => (
     <span style={{ whiteSpace: "pre-wrap" }}>{m}</span>
@@ -169,8 +171,8 @@ export const useHudListenersService = () => {
         variant: "warning",
         autoHideDuration: getNotiDuration(message) * 1000,
         anchorOrigin: {
-          horizontal: "center",
-          vertical: "top",
+          horizontal: notiPos.horizontal,
+          vertical: notiPos.vertical,
         },
       }
     );

--- a/menu/src/state/server.state.ts
+++ b/menu/src/state/server.state.ts
@@ -1,4 +1,4 @@
-import { atom, useRecoilValue, useSetRecoilState } from "recoil";
+import { atom, selector, useRecoilValue, useSetRecoilState } from "recoil";
 import config from "../utils/config.json";
 
 interface OneSyncCtx {
@@ -17,17 +17,61 @@ export interface ServerCtx {
   projectName: null | string;
   maxClients: number;
   locale: string;
-  localeData: CustomLocaleData | false;
+  localeData: CustomLocaleData | boolean;
   switchPageKey: string;
+  announceNotiPos: string;
   txAdminVersion: string;
   alignRight: boolean;
 }
 
 const serverCtx = atom<ServerCtx>({
   key: "serverCtx",
-  default: <ServerCtx>config.serverCtx,
+  default: config.serverCtx,
 });
 
 export const useServerCtxValue = () => useRecoilValue(serverCtx);
 
 export const useSetServerCtx = () => useSetRecoilState(serverCtx);
+
+interface AnnounceNotiLocation {
+  vertical: "top" | "bottom";
+  horizontal: "left" | "right" | "center";
+}
+
+const verifyNotiLocation = (vertical, horizontal) => {
+  if (vertical !== "top" && vertical !== "bottom") {
+    throw new Error(
+      `Notification vertical position must be "top" or "bottom", but got ${vertical}`
+    );
+  }
+
+  if (
+    horizontal !== "left" &&
+    horizontal !== "right" &&
+    horizontal !== "center"
+  ) {
+    throw new Error(
+      `Notification horizontal position must be "left", "right" or "center", but got ${horizontal}`
+    );
+  }
+
+  return { vertical, horizontal };
+};
+
+const notiLocationSelector = selector<AnnounceNotiLocation>({
+  key: "notiLocation",
+  get: ({ get }) => {
+    const notiTgtRaw = get(serverCtx).announceNotiPos;
+    const [vertical, horizontal] = notiTgtRaw.split("-");
+
+    try {
+      return verifyNotiLocation(vertical, horizontal);
+    } catch (e) {
+      console.error(e);
+      return { vertical: "top", horizontal: "center" };
+    }
+  },
+});
+
+export const useAnnounceNotiPosValue = () =>
+  useRecoilValue(notiLocationSelector);

--- a/menu/src/utils/config.json
+++ b/menu/src/utils/config.json
@@ -6,6 +6,7 @@
       "type": null,
       "status": false
     },
+    "announceNotiPos": "top-center",
     "projectName": "Context Loading...",
     "maxClients": 48,
     "switchPageKey": "Tab",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13975,6 +13975,7 @@
       "integrity": "sha512-ulv2dvwurP/MZAIthXm69bO7EzzIUThZ6RJ1qXhdlXM6to3F+IKBL/17EnhYSG52A5N1KcAUu66vSG/3/77KrA==",
       "dev": true,
       "requires": {
+        "cosmiconfig": "^7",
         "ts-node": "^10.4.0"
       }
     },

--- a/scripts/cl_main.lua
+++ b/scripts/cl_main.lua
@@ -30,10 +30,9 @@ end)
 -- =============================================
 -- Dispatch Announcements
 RegisterNetEvent('txAdmin:receiveAnnounce', function(message, author)
-    print('txAdmin:receiveAnnounce', message)
     sendMenuMessage(
         'addAnnounceMessage',
-        { 
+        {
             message = message,
             author = author
         }

--- a/scripts/menu/server/sv_base.lua
+++ b/scripts/menu/server/sv_base.lua
@@ -16,7 +16,10 @@ ServerCtxObj = {
   localeData = nil,
   switchPageKey = '',
   txAdminVersion = '',
-  alignRight = false
+  alignRight = false,
+  -- possible states
+  -- top-center, top-right, top-left, bottom-center, bottom-right, bottom-left
+  announceNotiPos = '',
 }
 
 
@@ -54,23 +57,23 @@ local function getCustomLocaleData()
 
   -- Get file data
   local fileHandle = io.open(filePath, "rb")
-  if not fileHandle then 
+  if not fileHandle then
     print('^1WARNING: failed to load custom locale from path: '..filePath)
-    return false 
+    return false
   end
   local fileData = fileHandle:read "*a"
   fileHandle:close()
 
   -- Parse and validate data
   local locale = json.decode(fileData)
-  if 
-    not locale 
+  if
+    not locale
     or type(locale['$meta']) ~= "table"
     or type(locale['nui_warning']) ~= "table"
     or type(locale['nui_menu']) ~= "table"
   then
     print('^1WARNING: load or validate custom locale JSON data from path: '..filePath)
-    return false 
+    return false
   end
 
   -- Build response
@@ -81,7 +84,6 @@ local function getCustomLocaleData()
     ['nui_menu'] = locale['nui_menu'],
   }
 end
-
 
 local function syncServerCtx()
   local oneSyncConvar = GetConvar('onesync', 'off')
@@ -121,6 +123,16 @@ local function syncServerCtx()
     ServerCtxObj.localeData = getCustomLocaleData()
   else
     ServerCtxObj.localeData = false
+  end
+
+  local announceNotiPos = GetConvar('txAdmin-announceNotiPos', 'top-center')
+  -- verify we have a valid position type
+  if announceNotiPos == 'top-center' or announceNotiPos == 'top-right' or announceNotiPos == 'top-left' or announceNotiPos == 'bottom-center' or announceNotiPos == 'bottom-right' or announceNotiPos == 'bottom-left' then
+    ServerCtxObj.announceNotiPos = announceNotiPos
+  else
+    local errorMsg = ('^1Invalid notification position: %s, this must match one of the following "top-center, top-left, top-right, bottom-left, bottom-right, bottom-center" defaulting to "top-center"'):format(announceNotiPos)
+    txPrint(errorMsg)
+    ServerCtxObj.notificationPosition = 'top-center'
   end
 
   debugPrint('Updated ServerCtx.')

--- a/scripts/menu/shared.lua
+++ b/scripts/menu/shared.lua
@@ -13,6 +13,19 @@ function debugPrint(...)
   end
 end
 
+-- Used whenever we want to convey a message as from txAdminMenu without
+-- being in debug mode.
+function txPrint(...)
+  local args = {...}
+  local appendedStr = ''
+  for _, v in ipairs(args) do
+    appendedStr = appendedStr .. ' ' .. tostring(v)
+  end
+  local msgTemplate = '^3[txAdminMenu]^0%s^0'
+  local msg = msgTemplate:format(appendedStr)
+  print(msg)
+end
+
 CreateThread(function()
   debugModeEnabled = (GetConvar('txAdmin-menuDebug', 'false') == 'true')
 end)


### PR DESCRIPTION
Some servers would like to configure their announcement positioning as certain HUD elements may overlap. This allows for configuration in six different positions depending on the server's needs. For valid positions, see documentation.

Closes #561