### PR TITLE
refactor(menu/spectate): general cleanup + cycling feature

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -242,6 +242,7 @@
                         "bring_player": "Summoning player",
                         "spectate_failed": "Failed to resolve the target! Exiting spectate.",
                         "spectate_yourself": "You cannot spectate yourself.",
+                        "spectate_cycle_failed": "There are no players to cycle to!",
                         "freeze_yourself": "You cannot freeze yourself."
                     }
                 },

--- a/scripts/menu/client/cl_base.lua
+++ b/scripts/menu/client/cl_base.lua
@@ -13,7 +13,7 @@ lastTpCoords = false;
 local isMenuEnabled = (GetConvar('txAdmin-menuEnabled', 'false') == 'true')
 
 
--- Check if menu is in debug mode 
+-- Check if menu is in debug mode
 CreateThread(function()
   isMenuDebug = (GetConvar('txAdmin-menuDebug', 'false') == 'true')
 end)
@@ -78,6 +78,8 @@ RegisterNetEvent('txcl:setAdmin', function(username, perms, rejectReason)
     RegisterKeyMapping('txAdmin:menu:noClipToggle', 'Menu: Toggle NoClip', 'keyboard', '')
     RegisterKeyMapping('txAdmin:menu:togglePlayerIDs', 'Menu: Toggle Player IDs', 'KEYBOARD', '')
     RegisterKeyMapping('txAdmin:menu:endSpectate', 'Menu: Exit spectate mode', 'keyboard', 'BACK')
+    RegisterKeyMapping('txAdmin:menu:specNextPlayer', 'Menu: Cycle to next spectate target', 'KEYBOARD', 'DOWN')
+    RegisterKeyMapping('txAdmin:menu:specPrevPlayer', 'Menu: Cycle to previous spectate target', 'KEYBOARD', 'UP')
   else
     print("^3[AUTH] rejected (" .. tostring(rejectReason) ..")")
     menuIsAccessible = false
@@ -150,7 +152,7 @@ RegisterNUICallback('reactLoaded', function(aaa, cb)
   print("React loaded, sending variables.")
   sendMenuMessage('setDebugMode', isMenuDebug)
   sendMenuMessage('setPermissions', menuPermissions)
-  
+
   CreateThread(function()
     updateServerCtx()
     while ServerCtx == false do Wait(0) end

--- a/scripts/menu/client/cl_spectate.lua
+++ b/scripts/menu/client/cl_spectate.lua
@@ -14,7 +14,11 @@ local storedTargetPed
 local storedTargetPlayerId
 -- Spectated players associated GameTag
 local storedGameTag
+-- Spectated players associated server id
+local currentSpectateServerId
 
+-- Whether should we lock the camera to the target ped
+local isInTransitionState = false
 
 RegisterNUICallback('spectatePlayer', function(data, cb)
     TriggerServerEvent('txAdmin:menu:spectatePlayer', tonumber(data.id))
@@ -44,9 +48,22 @@ local function createScaleformThread()
 
         PushScaleformMovieFunction(scaleform, "SET_DATA_SLOT")
         PushScaleformMovieFunctionParameterInt(1)
-        InstructionalButton(GetControlInstructionalButton(1, 194), "Exit Spectate Mode")
+        -- Jooat hash of txAdmin:menu:specNextPlayer
+        InstructionalButton('~INPUT_698AE6AF~', "Next Player")
         PopScaleformMovieFunctionVoid()
 
+        PushScaleformMovieFunction(scaleform, "SET_DATA_SLOT")
+        PushScaleformMovieFunctionParameterInt(0)
+        -- Jooat hash of txAdmin:menu:specPrevPlayer
+        InstructionalButton('~INPUT_5E76B036~', "Previous Player")
+        PopScaleformMovieFunctionVoid()
+
+        -- Exit spectate button
+        PushScaleformMovieFunction(scaleform, "SET_DATA_SLOT")
+        PushScaleformMovieFunctionParameterInt(2)
+        -- Joat Hash for 'txAdmin:menu:endSpectate' command
+        InstructionalButton('~INPUT_417C207D~', "Exit Spectate Mode")
+        PopScaleformMovieFunctionVoid()
 
         PushScaleformMovieFunction(scaleform, "DRAW_INSTRUCTIONAL_BUTTONS")
         PopScaleformMovieFunctionVoid()
@@ -67,19 +84,22 @@ local function createScaleformThread()
 end
 
 local function calculateSpectatorCoords(coords)
-    return vec3(coords[1], coords[2], coords[3] - 15.0)
+    return vec3(coords.x, coords.y, coords.z - 15.0)
 end
 
 --- Called every 50 frames in SpectateMode to determine whether or not to recreate the GamerTag
 local function createGamerTagInfo()
-    if storedGameTag and IsMpGamerTagActive(storedGameTag) then return end
-    local nameTag = ('[%d] %s'):format(GetPlayerServerId(storedTargetPlayerId), GetPlayerName(storedTargetPlayerId))
-    storedGameTag = CreateFakeMpGamerTag(storedTargetPed, nameTag, false, false, '', 0, 0, 0, 0)
+    if not isInTransitionState then
+        local nameTag = ('[%d] %s'):format(GetPlayerServerId(storedTargetPlayerId), GetPlayerName(storedTargetPlayerId))
+        storedGameTag = CreateFakeMpGamerTag(storedTargetPed, nameTag, false, false, '', 0, 0, 0, 0)
+    end
     SetMpGamerTagVisibility(storedGameTag, 2, 1)  --set the visibility of component 2(healthArmour) to true
     SetMpGamerTagAlpha(storedGameTag, 2, 255) --set the alpha of component 2(healthArmour) to 255
-    SetMpGamerTagHealthBarColor(storedGameTag, 129) --set component 2(healthArmour) color to 129(HUD_COLOUR_YOGA)
-    SetMpGamerTagVisibility(storedGameTag, 4, NetworkIsPlayerTalking(i))
-    --debugPrint(('Created gamer tag for ped (%s), TargetPlayerID (%s)'):format(storedTargetPlayerId, storedTargetPlayerId))
+    SetMpGamerTagHealthBarColor(storedGameTag, 129)
+    SetMpGamerTagAlpha(storedGameTag, 4, 255) --set the alpha of component 1(name) to 255
+    SetMpGamerTagColour(storedGameTag, 4, 66)
+    SetMpGamerTagVisibility(storedGameTag, 4, NetworkIsPlayerTalking(storedTargetPlayerId))
+    --debugPrint(('Created gamer tag for ped (%s), TargetPlayerID (%s)'):format(storedTargetPed, storedTargetPlayerId))
 end
 
 --- Called to cleanup Gamer Tag's once spectate mode is disabled
@@ -95,6 +115,67 @@ local function preparePlayerForSpec(bool)
     local playerPed = PlayerPedId()
     FreezeEntityPosition(playerPed, bool)
     SetEntityVisible(playerPed, not bool, 0)
+end
+
+--- Will load collisions, tp the player, and invoke transition scaleforms
+--- @param coords table <string, number>
+--- @return void
+local function collisionTpCoordTransition(coords)
+    debugPrint('Collision TP init')
+    local playerPed = PlayerPedId()
+
+    -- Scaleform Transition
+    if not IsScreenFadedOut() then DoScreenFadeOut(500) end
+
+    while not IsScreenFadedOut() do Wait(0) end
+
+    RequestCollisionAtCoord(coords.x, coords.y, coords.z)
+    SetEntityCoords(playerPed, coords.x, coords.y, coords.z)
+    -- The player is still frozen while we wait for collisions to load
+    while not HasCollisionLoadedAroundEntity(playerPed) do
+        Wait(5)
+    end
+
+    debugPrint('Collisions loaded around player')
+end
+
+--- @param tgtPed number - The stored targeted ped for spectate
+local function disableSpectate(tgtPed)
+    preparePlayerForSpec(false)
+    isSpectateEnabled = false
+
+    storedSpectateTarget = nil
+    debugPrint('Disabling spectate process init')
+
+    DoScreenFadeOut(500)
+    while not IsScreenFadedOut() do Wait(0) end
+
+    if not lastSpectateLocation then
+        error('Last location previous to spectate was not stored properly')
+    end
+
+    if not storedTargetPed then
+        error('Target ped was not stored to unspectate')
+    end
+
+
+    NetworkSetInSpectatorMode(false, tgtPed)
+
+    preparePlayerForSpec(false)
+
+    debugPrint('Last Spectate Location')
+    debugPrint(lastSpectateLocation)
+    SetEntityCoords(PlayerPedId(), lastSpectateLocation.x, lastSpectateLocation.y, lastSpectateLocation.z)
+
+
+
+    DoScreenFadeIn(500)
+    while IsScreenFadingIn() do Wait(0) end
+
+    clearGamerTagInfo()
+    storedTargetPed = nil
+    isInTransitionState = false
+    currentSpectateServerId = nil
 end
 
 local function createSpectatorTeleportThread()
@@ -114,7 +195,7 @@ local function createSpectatorTeleportThread()
                     storedTargetPed = _ped
                 else
                     debugPrint(("Spectated player (%s) no longer exists, ending spectate..."):format(storedTargetPlayerId))
-                    toggleSpectate(storedTargetPed, storedTargetPlayerId)
+                    disableSpectate(storedTargetPed)
                     break
                 end
             end
@@ -126,108 +207,90 @@ local function createSpectatorTeleportThread()
     end)
 end
 
---- Will toggle spectate for a targeted ped
---- @param targetPed nil|number - The target ped when toggling on, can be nil when toggling off
-local function toggleSpectate(targetPed, targetPlayerId)
-    local playerPed = PlayerPedId()
 
-    if isSpectateEnabled then
-        isSpectateEnabled = false
 
-        if not lastSpectateLocation then
-            error('Last location previous to spectate was not stored properly')
-        end
+--- @param tgtPed number - The ped to spectate
+--- @param tgtPlayerId number - The player id to spectate
+--- @param tgtTpCoords table<string, number> - The coords to teleport to
+local function spectateTgtAtCoords(tgtPed, tgtTpCoords)
+    local targetCoords = calculateSpectatorCoords(tgtTpCoords)
+    debugPrint(('Targets coords = x: %f, y: %f, z: %f'):format(targetCoords.x, targetCoords.y, targetCoords.z))
 
-        if not storedTargetPed then
-            error('Target ped was not stored to unspectate')
-        end
+    collisionTpCoordTransition(targetCoords)
+    NetworkSetInSpectatorMode(true, tgtPed)
+    debugPrint(('Set spectate to true for targetPed (%s)'):format(tgtPed))
 
-        DoScreenFadeOut(500)
-        while not IsScreenFadedOut() do Wait(0) end
-
-        RequestCollisionAtCoord(lastSpectateLocation.x, lastSpectateLocation.y, lastSpectateLocation.z)
-        SetEntityCoords(playerPed, lastSpectateLocation.x, lastSpectateLocation.y, lastSpectateLocation.z)
-        -- The player is still frozen while we wait for collisions to load
-        while not HasCollisionLoadedAroundEntity(playerPed) do
-            Wait(5)
-        end
-        debugPrint('Collisions loaded around player')
-
-        preparePlayerForSpec(false)
-        debugPrint('Unfreezing current player')
-
-        NetworkSetInSpectatorMode(false, storedTargetPed)
-        debugPrint(('Set spectate to false for targetPed (%s)'):format(storedTargetPed))
-        clearGamerTagInfo()
+    if IsScreenFadedOut then
         DoScreenFadeIn(500)
-
-        storedTargetPed = nil
-    else
-        storedTargetPed = targetPed
-        storedTargetPlayerId = targetPlayerId
-        local targetCoords = GetEntityCoords(targetPed)
-        debugPrint(('Targets coords = x: %f, y: %f, z: %f'):format(targetCoords.x, targetCoords.y, targetCoords.z))
-
-        RequestCollisionAtCoord(targetCoords.x, targetCoords.y, targetCoords.z)
-        while not HasCollisionLoadedAroundEntity(targetPed) do
-            Wait(5)
-        end
-        debugPrint(('Collisions loaded around TargetPed (%s)'):format(targetPed))
-
-        NetworkSetInSpectatorMode(true, targetPed)
-        DoScreenFadeIn(500)
-        debugPrint(('Now spectating TargetPed (%s)'):format(targetPed))
-        isSpectateEnabled = true
-        createSpectatorTeleportThread()
-        createScaleformThread()
     end
+
+    createGamerTagInfo()
+    createSpectatorTeleportThread()
+    createScaleformThread()
+    isSpectateEnabled = true
+    isInTransitionState = false
 end
 
 RegisterCommand('txAdmin:menu:endSpectate', function()
-    if isSpectateEnabled then
-        toggleSpectate(storedTargetPed)
-        preparePlayerForSpec(false)
-        TriggerServerEvent('txAdmin:menu:endSpectate')
-    end
+    -- We don't want this triggering when menu is open or when spectate isn't enabled
+    if not isSpectateEnabled or isMenuVisible then return end
+
+    disableSpectate(storedTargetPed)
+    TriggerServerEvent('txAdmin:menu:endSpectate')
 end)
 
--- Run whenever we failed to resolve a target player to spectate
+--- @param isNext boolean - If true, will spectate the next player in the list
+local function handleSpecCycle(isNext)
+    -- We don't want to cycle if the player is moving down the menu using arrow keys
+    -- or if pause is open, or if spectate isn't enabled
+    if isMenuVisible or IsPauseMenuActive() or not isSpectateEnabled then
+        return
+    end
+
+    if isInTransitionState then
+        return debugPrint('Currently in transition moment, cannot spectate next player')
+    end
+
+    debugPrint(('Spectate enabled: %s | Spectating: %s'):format(tostring(isSpectateEnabled), tostring(currentSpectateServerId)))
+    if not isSpectateEnabled or currentSpectateServerId == nil then return end
+    TriggerServerEvent('txAdmin:menu:specPlayerCycle', currentSpectateServerId, isNext)
+end
+
+RegisterCommand('txAdmin:menu:specNextPlayer', function()
+    handleSpecCycle(true)
+end)
+
+RegisterCommand('txAdmin:menu:specPrevPlayer', function()
+    handleSpecCycle(false)
+end)
+
+--- Ran if we failed to resolve a target player to spectate
+--- @return void
 local function cleanupFailedResolve()
     local playerPed = PlayerPedId()
 
     RequestCollisionAtCoord(lastSpectateLocation.x, lastSpectateLocation.y, lastSpectateLocation.z)
     SetEntityCoords(playerPed, lastSpectateLocation.x, lastSpectateLocation.y, lastSpectateLocation.z)
     -- The player is still frozen while we wait for collisions to load
-    while not HasCollisionLoadedAroundEntity(playerPed) do
-        Wait(5)
-    end
+
     preparePlayerForSpec(false)
 
     DoScreenFadeIn(500)
-
+    -- At this point, we can remove the lock for transition state
+    isInTransitionState = false
     sendSnackbarMessage('error', 'nui_menu.player_modal.actions.interaction.notifications.spectate_failed', true)
+    clearGamerTagInfo()
+    storedTargetPlayerId = nil
+    storedTargetPed = nil
 end
 
--- Client-side event handler for an authorized spectate request
-RegisterNetEvent('txAdmin:menu:specPlayerResp', function(targetServerId, coords)
-    local spectatorPed = PlayerPedId()
-    lastSpectateLocation = GetEntityCoords(spectatorPed)
-
-    local targetPlayerId = GetPlayerFromServerId(targetServerId)
-    if targetPlayerId == PlayerId() then
-        return sendSnackbarMessage('error', 'nui_menu.player_modal.actions.interaction.notifications.spectate_yourself', true)
-    end
-
-    DoScreenFadeOut(500)
-    while not IsScreenFadedOut() do Wait(0) end
-
-    local tpCoords = calculateSpectatorCoords(coords)
-    SetEntityCoords(spectatorPed, tpCoords.x, tpCoords.y, tpCoords.z, 0, 0, 0, false)
-    preparePlayerForSpec(true)
-
-    --- We need to wait to make sure that the player is actually available once we teleport
-    --- this can take some time so we do this. Automatically breaks if a player isn't resolved
-    --- within 5 seconds.
+--- We need to wait to make sure that the player is actually available once we teleport
+--- this can take some time so we do this. Automatically breaks if a player isn't resolved
+--- within 5 seconds.
+--- @param tgtServerId number - The server id of the player to target spectating for
+--- @return number - The resolved target ped
+local function tryToResolvePlayerPed(tgtServerId)
+    local tgtPlayerId = GetPlayerFromServerId(tgtServerId)
     local resolvePlayerAttempts = 0
     local resolvePlayerFailed
 
@@ -238,21 +301,75 @@ RegisterNetEvent('txAdmin:menu:specPlayerResp', function(targetServerId, coords)
         end
         Wait(50)
         debugPrint('Waiting for player to resolve')
-        targetPlayerId = GetPlayerFromServerId(targetServerId)
+        tgtPlayerId = GetPlayerFromServerId(tgtServerId)
         resolvePlayerAttempts = resolvePlayerAttempts + 1
-    until (GetPlayerPed(targetPlayerId) > 0) and targetPlayerId ~= -1
+    until (GetPlayerPed(tgtPlayerId) > 0) and tgtPlayerId ~= -1
 
     if resolvePlayerFailed then
-        return cleanupFailedResolve()
+        cleanupFailedResolve()
+        error('Failed to resolve player to spectate')
     end
 
     debugPrint('Target Ped successfully found!')
-    toggleSpectate(GetPlayerPed(targetPlayerId), targetPlayerId)
+
+    return GetPlayerPed(tgtPlayerId)
+end
+
+-- Client-side event handler for an authorized spectate request
+RegisterNetEvent('txAdmin:menu:specPlayerResp', function(targetServerId, coords)
+    if isInTransitionState then
+        error('Spectate request received while in transition state')
+        disableSpectate(storedTargetPed)
+    end
+
+    clearGamerTagInfo()
+
+    local curPed = PlayerPedId()
+    lastSpectateLocation = GetEntityCoords(curPed)
+    currentSpectateServerId = targetServerId
+
+    local targetPlayerId = GetPlayerFromServerId(targetServerId)
+    if targetPlayerId == PlayerId() then
+        return sendSnackbarMessage('error', 'nui_menu.player_modal.actions.interaction.notifications.spectate_yourself', true)
+    end
+
+    isInTransitionState = true
+
+    local gameTime = GetGameTimer()
+
+    DoScreenFadeOut(500)
+    while not IsScreenFadedOut() do
+        if gameTime + 15000 < GetGameTimer() then
+            cleanupFailedResolve()
+            error('Failed to resolve player to spectate')
+        end
+        Wait(0)
+    end
+
+    local tpCoords = calculateSpectatorCoords(coords)
+    SetEntityCoords(curPed, tpCoords.x, tpCoords.y, tpCoords.z, 0, 0, 0, false)
+    preparePlayerForSpec(true)
+
+    targetPlayerId = GetPlayerFromServerId(targetServerId)
+
+    debugPrint('Resolve target player id')
+
+    local resolvedPed = tryToResolvePlayerPed(targetServerId)
+    debugPrint('Resolved target player ped: ' .. tostring(resolvedPed))
+    storedTargetPed = resolvedPed
+
+    storedTargetPlayerId = GetPlayerFromServerId(targetServerId)
+
+    spectateTgtAtCoords(resolvedPed, tpCoords)
+end)
+
+RegisterNetEvent('txAdmin:menu:specPlayerCycleFail', function()
+    sendSnackbarMessage('error', 'nui_menu.player_modal.actions.interaction.notifications.spectate_cycle_failed', true)
 end)
 
 CreateThread(function()
     while true do
-        if isSpectateEnabled then
+        if isSpectateEnabled and not isInTransitionState then
             createGamerTagInfo()
         else
             clearGamerTagInfo()

--- a/scripts/menu/server/sv_spectate.lua
+++ b/scripts/menu/server/sv_spectate.lua
@@ -3,11 +3,8 @@ if GetConvar('txAdminServerMode', 'false') ~= 'true' then
   return
 end
 
--- Holds map containing source players original routing
--- bucket so we can use it on end spectate.
-local ORIGINAL_SPEC_BUCKET = {}
-
-RegisterNetEvent('txAdmin:menu:spectatePlayer', function(id)
+--- @param id number The player id to spectate.
+local function handleSpectatePlayer(id)
   local src = source
   -- Sanity as this is still converted tonumber on client side
   if type(id) ~= 'string' and type(id) ~= 'number' then
@@ -34,36 +31,89 @@ RegisterNetEvent('txAdmin:menu:spectatePlayer', function(id)
     -- and we don't need to store data in the map
     if tgtBucket ~= srcBucket then
       debugPrint(('Target and source buckets differ | src: %s, bkt: %i | tgt: %s, bkt: %i'):format(src, srcBucket, target, tgtBucket))
-      ORIGINAL_SPEC_BUCKET[src] = srcBucket
+      tgtPlayerStateBag.state.__prevRoutingBucket = GetPlayerRoutingBucket(src)
+
       SetPlayerRoutingBucket(src, tgtBucket)
     end
+
+    -- txAdmin statebags should probably be implemented using
+    -- under score private keys, so we don't have servers randomly
+    -- messingw with our state
+    local tgtPlayerStateBag = Player(src).state
+
+    tgtPlayerStateBag.__txAdminSpectating = true
+    tgtPlayerStateBag.__txAdminSpectateTgt = id
 
     local tgtCoords = GetEntityCoords(target)
     TriggerClientEvent('txAdmin:menu:specPlayerResp', src, id, tgtCoords)
   end
   TriggerEvent('txaLogger:menuEvent', src, 'spectatePlayer', allow, id)
+end
+
+--- Operates under the assummption that GetPlayers is returning a sorted array
+--- @param curTgtId number The current spectate target id.
+--- @param isNext boolean Whether to target an id greater than current
+--- @param players table<string> The array of players to target.
+--- @param src number The current source id.
+--- @return number The spectate target id to target next
+local function findNextTgtId(curTgtId, players, isNext)
+  -- returns -1 if the spectateTgtId is not found
+  local currentTgtServerIdx = tableIndexOf(players, tostring(curTgtId))
+
+  if currentTgtServerIdx < 0 then
+    return error('Current spectate target id not found for online players')
+  end
+
+  if isNext then
+    return players[currentTgtServerIdx + 1] or players[1]
+  else
+    return players[currentTgtServerIdx - 1] or players[#players]
+  end
+end
+
+--- @param curTgtId number The current target id.
+--- @param isNextPlayer boolean If we should cycle to the next player or not.
+RegisterNetEvent('txAdmin:menu:specPlayerCycle', function(curTgtId, isNextPlayer)
+  local src = source
+  local allow = PlayerHasTxPermission(src, 'players.spectate')
+
+  if allow then
+    local onlinePlayers = GetPlayers()
+    -- We don't allow cycling if there are less than two players online.
+    if #onlinePlayers <= 2 then return TriggerClientEvent("txAdmin:menu:specPlayerCycleFail", src) end
+
+    -- Find idx of current src
+    local srcTgtIdx = tableIndexOf(onlinePlayers, tostring(src))
+
+    -- Filter out the current src from the online players list
+    table.remove(onlinePlayers, srcTgtIdx)
+
+    local nextTgtId = findNextTgtId(curTgtId, onlinePlayers, isNextPlayer, src)
+
+    local isPrevOrNext = isNextPlayer and 'next' or 'prev'
+
+    debugPrint(('Cycling to %s player | src: %s, curTgtId: %s, nextTgtId: %s'):format(isPrevOrNext, src, curTgtId, nextTgtId))
+
+    handleSpectatePlayer(nextTgtId)
+  end
 end)
+
+RegisterNetEvent('txAdmin:menu:spectatePlayer', handleSpectatePlayer)
 
 RegisterNetEvent('txAdmin:menu:endSpectate', function()
   local src = source
   local allow = PlayerHasTxPermission(src, 'players.spectate')
   if allow then
+    local tgtPlayerStateBag = Player(src).state
     -- If this is nil, assume that no routing bucket change is needed,
     -- as it wasn't stored
-    local prevRoutBucket = ORIGINAL_SPEC_BUCKET[src]
+    local prevRoutBucket = tgtPlayerStateBag.__prevRoutingBucket
     -- Since lua treats 0 as truthy, actually don't need to handle
     -- explicit nil check for int 0
     if prevRoutBucket then
       SetPlayerRoutingBucket(src, prevRoutBucket)
-      -- Clean up our prev bucket map
-      ORIGINAL_SPEC_BUCKET[src] = nil
+      tgtPlayerStateBag.__prevRoutingBucket = nil
     end
   end
 end)
 
-AddEventHandler('playerDropped', function()
-  local src = source
-  if ORIGINAL_SPEC_BUCKET[src] then
-    ORIGINAL_SPEC_BUCKET[src] = nil
-  end
-end)

--- a/scripts/menu/shared.lua
+++ b/scripts/menu/shared.lua
@@ -29,3 +29,13 @@ end
 CreateThread(function()
   debugModeEnabled = (GetConvar('txAdmin-menuDebug', 'false') == 'true')
 end)
+
+function tableIndexOf(tgtTable, value)
+  for i=1, #tgtTable do
+    debugPrint(('tgtTableVal: %s, value: %s'):format(tgtTable[i], value))
+    if tgtTable[i] == value then
+      return i
+    end
+  end
+  return -1
+end


### PR DESCRIPTION
This cleanups up our spectate system a little bit to hopefully help with readability and logic flow. 

But, much of it still relies heavily on side effects that make me weep :(

This also adds the ability cycle between players as a feature, so users wouldn't have to click on each individual player in order to spectate them.

Still needs to be tested for bucket compatibility and a few things I may have missed while writing.
