### PR TITLE
Context Variable - Master Principal Identifier

### DIFF
--- a/src/webroutes/deployer/actions.js
+++ b/src/webroutes/deployer/actions.js
@@ -151,6 +151,11 @@ async function handleSetVariables(ctx) {
         ? addPrincipalLines.join('\n')
         : '# Deployer Note: this admin master has no identifiers to be automatically added.\n# add_principal identifier.discord.111111111111111111 group.admin #example';
 
+    // Master Principal Identifier
+    userVars.principalMasterIdentifier = (admin.providers.length)
+        ? admin.providers[1]
+        : 'none:none';
+
     //Start deployer
     try {
         ctx.utils.logAction('Running recipe.');


### PR DESCRIPTION
Add a new context variable users are able to utilize to automatically assign the master to any custom principal instead of just the default group.admin. 