### PR TITLE
Improve passwords

### DIFF
--- a/src/components/configVault.js
+++ b/src/components/configVault.js
@@ -117,6 +117,12 @@ module.exports = class ConfigVault {
                 menuEnabled: toDefault(cfg.global.menuEnabled, true),
                 menuAlignRight: toDefault(cfg.global.menuAlignRight, false),
                 menuPageKey: toDefault(cfg.global.menuPageKey, 'Tab'),
+                passwordMinLength: toDefault(cfg.global.passwordMinLength, 8),
+                passwordMaxLength: toDefault(cfg.global.passwordMaxLength, 24),
+                passwordLowercaseLetter: toDefault(cfg.global.passwordLowercaseLetter, true),
+                passwordUppercaseLetter: toDefault(cfg.global.passwordUppercaseLetter, true),
+                passwordNumber: toDefault(cfg.global.passwordNumber, true),
+                passwordSpecialCharacter: toDefault(cfg.global.passwordSpecialCharacter, false),
             };
             out.logger = toDefault(cfg.logger, {}); //not in template
             out.monitor = {
@@ -194,7 +200,12 @@ module.exports = class ConfigVault {
             cfg.global.language = cfg.global.language || 'en'; //TODO: move to GlobalData
             cfg.global.menuEnabled = (cfg.global.menuEnabled === 'true' || cfg.global.menuEnabled === true);
             cfg.global.menuAlignRight = (cfg.global.menuAlignRight === 'true' || cfg.global.menuAlignRight === true);
-            cfg.global.menuPageKey = cfg.global.menuPageKey || 'Tab';
+            cfg.global.passwordMinLength = toDefault(cfg.global.passwordMinLength, 8);
+            cfg.global.passwordMaxLength = toDefault(cfg.global.passwordMaxLength, 24);
+            cfg.global.passwordLowercaseLetter = toDefault(cfg.global.passwordLowercaseLetter, true);
+            cfg.global.passwordUppercaseLetter = toDefault(cfg.global.passwordUppercaseLetter, true);
+            cfg.global.passwordNumber = toDefault(cfg.global.passwordNumber, true);
+            cfg.global.passwordSpecialCharacter = toDefault(cfg.global.passwordSpecialCharacter, false);
 
             //Logger - NOTE: this one default's i'm doing directly into the class
             cfg.logger.fxserver = toDefault(cfg.logger.fxserver, {});

--- a/src/components/webServer/ctxUtils.js
+++ b/src/components/webServer/ctxUtils.js
@@ -268,6 +268,17 @@ module.exports = async function WebCtxUtils(ctx, next) {
             globals.databus.txStatsData.pageViews[view]++;
         }
 
+        // Get config global scope, to get password settings
+        const cfg = globals.configVault.getScoped('global');
+        const password = {  
+            minLength: cfg.passwordMinLength,
+            maxLength: cfg.passwordMaxLength,
+            lowercaseLetter: cfg.passwordLowercaseLetter,
+            uppercaseLetter: cfg.passwordUppercaseLetter,
+            number: cfg.passwordNumber,
+            specialCharacter: cfg.passwordSpecialCharacter,
+        };
+
         // Setting up default render data:
         const baseViewData = {
             serverName: globals.config.serverName || globals.info.serverProfile,
@@ -278,6 +289,7 @@ module.exports = async function WebCtxUtils(ctx, next) {
             serverProfile: globals.info.serverProfile,
             txAdminVersion: GlobalData.txAdminVersion,
             uiTheme: (ctx.cookies.get('txAdmin-darkMode') === 'true' || !isWebInterface) ? THEME_DARK : '',
+            passwordRequirements: password,
             jsInjection: getJavascriptConsts({
                 isWebInterface: isWebInterface,
                 TX_BASE_PATH: (isWebInterface) ? '' : WEBPIPE_PATH,

--- a/src/webroutes/authentication/addMaster.js
+++ b/src/webroutes/authentication/addMaster.js
@@ -166,11 +166,33 @@ async function handleSave(ctx) {
     //Sanity check2: Electric Boogaloo (Validating password)
     const password = ctx.request.body.password.trim();
     const password2 = ctx.request.body.password2.trim();
-    if (password != password2 || password.length < 6 || password.length > 24) {
+    if (password != password2) {
         return returnJustMessage(
             ctx,
-            'Invalid Password.',
+            'Passwords do not match.',
         );
+    }
+
+    const cfg = globals.configVault.getScoped('global');
+
+    if (password.length < cfg.passwordMinLength || password.length > cfg.passwordMaxLength) {
+        return returnJustMessage(ctx, `The new password has to be between ${cfg.passwordMinLength} and ${cfg.passwordMaxLength} characters.`);
+    }
+
+    if (cfg.passwordLowercaseLetter && !password.match(/(?=.*[a-z])/)) {
+        return returnJustMessage(ctx, 'The new password must contain at least one lowercase letter.');
+    }
+
+    if (cfg.passwordUppercaseLetter && !password.match(/(?=.*[A-Z])/)) {
+        return returnJustMessage(ctx, 'The new password must contain at least one uppercase letter.');
+    }
+
+    if (cfg.passwordNumber && !password.match(/(?=.*\d)/)) {
+        return returnJustMessage(ctx, 'The new password must contain at least one number.');
+    }
+
+    if (cfg.passwordSpecialCharacter && !password.match(/(?=.*[#$@!%&*?])/)) {
+        return returnJustMessage(ctx, 'The new password must contain at least one special character.');
     }
 
     //Checking if ToS/License accepted

--- a/src/webroutes/authentication/changePassword.js
+++ b/src/webroutes/authentication/changePassword.js
@@ -30,8 +30,20 @@ module.exports = async function AuthChangePassword(ctx) {
             return ctx.send({type: 'danger', message: 'Wrong current password'});
         }
     }
-    if (newPassword.length < 6 || newPassword.length > 32) {
-        return ctx.send({type: 'danger', message: 'Invalid new password'});
+    if (newPassword.length < 8 || newPassword.length > 24) {
+        return ctx.send({type: 'danger', message: 'The new password has to be between 8 and 24 characters.'});
+    }
+    if (!newPassword.match(/(?=.*[a-z])/)) {
+        return ctx.send({type: 'danger', message: 'The new password must contain at least one lowercase letter'});
+    }
+    if (!newPassword.match(/(?=.*[A-Z])/)) {
+        return ctx.send({type: 'danger', message: 'The new password must contain at least one uppercase letter'});
+    }
+    if (!newPassword.match(/(?=.*\d)/)) {
+        return ctx.send({type: 'danger', message: 'The new password must contain at least one number'});
+    }
+    if (!newPassword.match(/(?=.*[#$@!%&*?])/)) {
+        return ctx.send({type: 'danger', message: 'The new password must contain at least one special character'});
     }
 
     //Add admin and give output

--- a/src/webroutes/authentication/changePassword.js
+++ b/src/webroutes/authentication/changePassword.js
@@ -30,20 +30,27 @@ module.exports = async function AuthChangePassword(ctx) {
             return ctx.send({type: 'danger', message: 'Wrong current password'});
         }
     }
-    if (newPassword.length < 8 || newPassword.length > 24) {
-        return ctx.send({type: 'danger', message: 'The new password has to be between 8 and 24 characters.'});
+
+    const cfg = globals.configVault.getScoped('global');
+
+    if (newPassword.length < cfg.passwordMinLength || newPassword.length > cfg.passwordMaxLength) {
+        return ctx.send({type: 'danger', message: `The new password has to be between ${cfg.passwordMinLength} and ${cfg.passwordMaxLength} characters.`});
     }
-    if (!newPassword.match(/(?=.*[a-z])/)) {
-        return ctx.send({type: 'danger', message: 'The new password must contain at least one lowercase letter'});
+
+    if (cfg.passwordLowercaseLetter && !newPassword.match(/(?=.*[a-z])/)) {
+        return ctx.send({type: 'danger', message: 'The new password must contain at least one lowercase letter.'});
     }
-    if (!newPassword.match(/(?=.*[A-Z])/)) {
-        return ctx.send({type: 'danger', message: 'The new password must contain at least one uppercase letter'});
+
+    if (cfg.passwordUppercaseLetter && !newPassword.match(/(?=.*[A-Z])/)) {
+        return ctx.send({type: 'danger', message: 'The new password must contain at least one uppercase letter.'});
     }
-    if (!newPassword.match(/(?=.*\d)/)) {
-        return ctx.send({type: 'danger', message: 'The new password must contain at least one number'});
+
+    if (cfg.passwordNumber && !newPassword.match(/(?=.*\d)/)) {
+        return ctx.send({type: 'danger', message: 'The new password must contain at least one number.'});
     }
-    if (!newPassword.match(/(?=.*[#$@!%&*?])/)) {
-        return ctx.send({type: 'danger', message: 'The new password must contain at least one special character'});
+
+    if (cfg.passwordSpecialCharacter && !newPassword.match(/(?=.*[#$@!%&*?])/)) {
+        return ctx.send({type: 'danger', message: 'The new password must contain at least one special character.'});
     }
 
     //Add admin and give output

--- a/web/basic/footer.html
+++ b/web/basic/footer.html
@@ -227,7 +227,7 @@
                     </div>
                     <div class="col-sm-12">
                         <span class="form-text text-muted text-center">
-                            The new password has to be between 6 and 24 characters.
+                            The new password has to be between 8 and 24 characters. Also must contain at least: one lowercase letter, one uppercase letter, one number and one special character.
                         </span>
                     </div>
                 </div>

--- a/web/basic/footer.html
+++ b/web/basic/footer.html
@@ -200,7 +200,7 @@
                             </label>
                             <div class="input-group">
                                 <input type="password" autocomplete="new-password" class="form-control text-center"
-                                    id="modChangePassword-oldPassword" maxlength="64">
+                                    id="modChangePassword-oldPassword">
                             </div>
                         </div>
                         <div class="col-sm-12" style="margin-top: 1.75em;"></div>
@@ -213,7 +213,7 @@
                         </label>
                         <div class="input-group">
                             <input type="password" autocomplete="new-password" class="form-control text-center"
-                                id="modChangePassword-newPassword" maxlength="24">
+                                id="modChangePassword-newPassword" maxlength="<%= passwordRequirements.maxLength %>" oninput="onPasswordChange('modChangePassword-newPassword')">
                         </div>
                     </div>
                     <div class="col-sm-8 mx-auto">
@@ -225,10 +225,23 @@
                                 id="modChangePassword-confirmPassword">
                         </div>
                     </div>
-                    <div class="col-sm-12">
-                        <span class="form-text text-muted text-center">
-                            The new password has to be between 8 and 24 characters. Also must contain at least: one lowercase letter, one uppercase letter, one number and one special character.
-                        </span>
+                    <div class="col-sm-8 mx-auto">
+                        <p class="form-text text-muted text-left mt-3">Password requirements:</p>
+                        <ul class="form-text text-muted text-left">
+                            <li id="password-length" class="text-danger">Password length between <span id="password-minLength"><%= passwordRequirements.minLength %></span> and <span id="password-maxLength"><%= passwordRequirements.maxLength %></span> characters</li>
+                            <% if (passwordRequirements.lowercaseLetter) { %>
+                                <li id="password-lowercaseLetter" class="text-danger">One lowercase letter</li>
+                            <% } %>
+                            <% if (passwordRequirements.uppercaseLetter) { %>
+                                <li id="password-uppercaseLetter" class="text-danger">One uppercase letter</li>
+                            <% } %>
+                            <% if (passwordRequirements.number) { %>
+                                <li id="password-number" class="text-danger">One number</li>
+                            <% } %>
+                            <% if (passwordRequirements.specialCharacter) { %>
+                                <li id="password-specialCharacter" class="text-danger">One special charater</li>
+                            <% } %>
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/web/basic/login.html
+++ b/web/basic/login.html
@@ -241,7 +241,7 @@
                                         placeholder="Confirm Password" autocomplete="new-password" required>
                                 </div>
                                 <span class="form-text text-muted mb-4">
-                                    Must be between 6 and 24 characters.
+                                    The new password has to be between 8 and 24 characters. Also must contain at least: one lowercase letter, one uppercase letter, one number and one special character.
                                 </span>
 
                                 <div class="input-group mx-auto mb-2" style="max-width: 280px;">

--- a/web/basic/login.html
+++ b/web/basic/login.html
@@ -229,7 +229,7 @@
                                         </span>
                                     </div>
                                     <input class="form-control" type="password" name="password" id="password"
-                                        placeholder="Password" autocomplete="new-password" minlength="6" maxlength="24" autofocus required>
+                                        placeholder="Password" autocomplete="new-password" minlength="<%= passwordRequirements.minLength %>" maxlength="<%= passwordRequirements.maxLength %>" oninput="onPasswordChange('password')" autofocus required>
                                 </div>
                                 <div class="input-group mx-auto" style="max-width: 280px;">
                                     <div class="input-group-prepend">
@@ -241,7 +241,22 @@
                                         placeholder="Confirm Password" autocomplete="new-password" required>
                                 </div>
                                 <span class="form-text text-muted mb-4">
-                                    The new password has to be between 8 and 24 characters. Also must contain at least: one lowercase letter, one uppercase letter, one number and one special character.
+                                    <p class="form-text text-muted text-left mt-3">Password requirements (you can change password and password requirements later):</p>
+                                    <ul class="form-text text-muted text-left">
+                                        <li id="password-length" class="text-danger">Password length between <span id="password-minLength"><%= passwordRequirements.minLength %></span> and <span id="password-maxLength"><%= passwordRequirements.maxLength %></span> characters</li>
+                                        <% if (passwordRequirements.lowercaseLetter) { %>
+                                            <li id="password-lowercaseLetter" class="text-danger">One lowercase letter</li>
+                                        <% } %>
+                                        <% if (passwordRequirements.uppercaseLetter) { %>
+                                            <li id="password-uppercaseLetter" class="text-danger">One uppercase letter</li>
+                                        <% } %>
+                                        <% if (passwordRequirements.number) { %>
+                                            <li id="password-number" class="text-danger">One number</li>
+                                        <% } %>
+                                        <% if (passwordRequirements.specialCharacter) { %>
+                                            <li id="password-specialCharacter" class="text-danger">One special charater</li>
+                                        <% } %>
+                                    </ul>
                                 </span>
 
                                 <div class="input-group mx-auto mb-2" style="max-width: 280px;">

--- a/web/public/js/txadmin/base.js
+++ b/web/public/js/txadmin/base.js
@@ -221,3 +221,70 @@ const txAdminPrompt = ({
     toggle1.addEventListener('click', handlerFn);
     toggle2.addEventListener('click', handlerFn);
 })();
+
+//================================================================
+//===================================== Change Password Validation
+//================================================================
+// Btw. placed here, because while in setup only this js file is used
+function onPasswordChange(passwordElement) {
+    const password = $(`#${passwordElement}`).val().trim();
+
+    const minLength = Number($('#password-minLength').text().trim());
+    const maxLength = Number($('#password-maxLength').text().trim());
+
+    const elementLength = $('#password-length');
+    const elementLowercaseLetter = $('#password-lowercaseLetter');
+    const elementUppercaseLetter = $('#password-uppercaseLetter');
+    const elementNumber = $('#password-number');
+    const elementSpecialCharacter = $('#password-specialCharacter');
+
+    if (elementLength.length) {
+        if (password.length >= minLength && password.length <= maxLength) {
+            elementLength.addClass('text-primary');
+            elementLength.removeClass('text-danger');
+        } else {
+            elementLength.addClass('text-danger');
+            elementLength.removeClass('text-primary');
+        }
+    }
+
+    if (elementLowercaseLetter.length) {
+        if (password.match(/(?=.*[a-z])/)) {
+            elementLowercaseLetter.addClass('text-primary');
+            elementLowercaseLetter.removeClass('text-danger');
+        } else {
+            elementLowercaseLetter.addClass('text-danger');
+            elementLowercaseLetter.removeClass('text-primary');
+        }
+    }
+
+    if (elementUppercaseLetter.length) {
+        if (password.match(/(?=.*[A-Z])/)) {
+            elementUppercaseLetter.addClass('text-primary');
+            elementUppercaseLetter.removeClass('text-danger');
+        } else {
+            elementUppercaseLetter.addClass('text-danger');
+            elementUppercaseLetter.removeClass('text-primary');
+        }
+    }
+
+    if (elementNumber.length) {
+        if (password.match(/(?=.*\d)/)) {
+            elementNumber.addClass('text-primary');
+            elementNumber.removeClass('text-danger');
+        } else {
+            elementNumber.addClass('text-danger');
+            elementNumber.removeClass('text-primary');
+        }
+    }
+
+    if (elementSpecialCharacter.length) {
+        if (password.match(/(?=.*[#$@!%&*?])/)) {
+            elementSpecialCharacter.addClass('text-primary');
+            elementSpecialCharacter.removeClass('text-danger');
+        } else {
+            elementSpecialCharacter.addClass('text-danger');
+            elementSpecialCharacter.removeClass('text-primary');
+        }
+    }
+}

--- a/web/public/js/txadmin/main.js
+++ b/web/public/js/txadmin/main.js
@@ -61,7 +61,10 @@ document.getElementById('modChangePassword-save').onclick = (e) => {
     };
 
     //Validity Checking
+    const minLength = Number($('#password-minLength').text().trim());
+    const maxLength = Number($('#password-maxLength').text().trim());
     const errors = [];
+
     if (!form.newPassword.length || !form.confirmPassword.length) {
         errors.push('The new password fields are required.');
     }
@@ -77,19 +80,19 @@ document.getElementById('modChangePassword-save').onclick = (e) => {
             errors.push('The new password must be different than the old one.');
         }
     }
-    if (form.newPassword.length < 8 || form.newPassword.length > 24) {
-        errors.push('The new password has to be between 8 and 24 characters.');
+    if (form.newPassword.length < minLength || form.newPassword.length > maxLength) {
+        errors.push(`The new password has to be between ${minLength} and ${maxLength} characters.`);
     }
-    if (!form.newPassword.match(/(?=.*[a-z])/)) {
+    if ($('#password-lowercaseLetter').length && !form.newPassword.match(/(?=.*[a-z])/)) {
         errors.push('The new password must contain at least one lowercase letter');
     }
-    if (!form.newPassword.match(/(?=.*[A-Z])/)) {
+    if ($('#password-uppercaseLetter').length && !form.newPassword.match(/(?=.*[A-Z])/)) {
         errors.push('The new password must contain at least one uppercase letter');
     }
-    if (!form.newPassword.match(/(?=.*\d)/)) {
+    if ($('#password-number').length && !form.newPassword.match(/(?=.*\d)/)) {
         errors.push('The new password must contain at least one number');
     }
-    if (!form.newPassword.match(/(?=.*[#$@!%&*?])/)) {
+    if ($('#password-specialCharacter').length && !form.newPassword.match(/(?=.*[#$@!%&*?])/)) {
         errors.push('The new password must contain at least one special character');
     }
     if (errors.length) {
@@ -127,7 +130,7 @@ document.getElementById('modChangePassword-save').onclick = (e) => {
 //================================================================
 //=================================================== On Page Load
 //================================================================
-document.addEventListener('DOMContentLoaded', function(event) {
+document.addEventListener('DOMContentLoaded', function (event) {
     //Setting up status refresh
     refreshData();
     setInterval(refreshData, STATUS_REFRESH_INTERVAL);

--- a/web/public/js/txadmin/main.js
+++ b/web/public/js/txadmin/main.js
@@ -77,8 +77,20 @@ document.getElementById('modChangePassword-save').onclick = (e) => {
             errors.push('The new password must be different than the old one.');
         }
     }
-    if (form.newPassword.length < 6 || form.newPassword.length > 24) {
-        errors.push('The new password has to be between 6 and 24 characters.');
+    if (form.newPassword.length < 8 || form.newPassword.length > 24) {
+        errors.push('The new password has to be between 8 and 24 characters.');
+    }
+    if (!form.newPassword.match(/(?=.*[a-z])/)) {
+        errors.push('The new password must contain at least one lowercase letter');
+    }
+    if (!form.newPassword.match(/(?=.*[A-Z])/)) {
+        errors.push('The new password must contain at least one uppercase letter');
+    }
+    if (!form.newPassword.match(/(?=.*\d)/)) {
+        errors.push('The new password must contain at least one number');
+    }
+    if (!form.newPassword.match(/(?=.*[#$@!%&*?])/)) {
+        errors.push('The new password must contain at least one special character');
     }
     if (errors.length) {
         return $.notify({ message: '<b>Errors:</b><br> - ' + errors.join(' <br>\n - ') }, { type: 'warning' });

--- a/web/settings.html
+++ b/web/settings.html
@@ -36,6 +36,9 @@
                     <li class="nav-item">
                         <a class="nav-item nav-link <%= activeTab === 'menu' ? 'active' : '' %>" id="nav-menu-tab" data-toggle="tab" href="#nav-menu" role="tab" aria-controls="nav-menu" aria-selected="true">Menu</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-item nav-link <%= activeTab === 'password' ? 'active' : '' %>" id="nav-password-tab" data-toggle="tab" href="#nav-password" role="tab" aria-controls="nav-password" aria-selected="true">Passwords</a>
+                    </li>
                 </ul>
             </div>
 
@@ -495,6 +498,96 @@
                     </div>
                     <!-- /Menu Tab -->
 
+                    <!-- Password Tab -->
+                    <div class="tab-pane fade <%= activeTab === 'password' ? 'active show' : '' %>" id="nav-password" role="tabpanel" aria-labelledby="nav-password-tab">
+                        <div class="form-group row">
+                            <label for="frmPassword-minLength" class="col-sm-3 col-form-label">Minimal length of password</label>
+                            <div class="col-sm-9">
+                                <input type="text" class="form-control" id="frmPassword-minLength"
+                                    value="<%= global.passwordMinLength || '' %>"
+                                    placeholder="8" <%= readOnly ? 'disabled' : '' %>>
+                                <span class="form-text text-muted">
+                                    Whats is the minimum amount of characters in password?
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label for="frmPassword-maxLength" class="col-sm-3 col-form-label">Maximum length of password</label>
+                            <div class="col-sm-9">
+                                <input type="text" class="form-control" id="frmPassword-maxLength"
+                                    value="<%= global.passwordMaxLength || '' %>"
+                                    placeholder="24" <%= readOnly ? 'disabled' : '' %>>
+                                <span class="form-text text-muted">
+                                    Whats is the maximum amount of characters in password?
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Lowercase letter</label>
+                            <div class="col-sm-9">
+                                <label class="c-switch c-switch-label c-switch-pill c-switch-success fix-pill-form">
+                                    <input class="c-switch-input" type="checkbox" id="frmPassword-lowercaseLetter"
+                                        <%= global.passwordLowercaseLetter || '' %> <%= readOnly ? 'disabled' : '' %>>
+                                    <span class="c-switch-slider" data-checked="Yes" data-unchecked="No"></span>
+                                </label>
+                                <span class="form-text text-muted">
+                                    Should password must contain at least one lowercase letter?
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Uppercase letter</label>
+                            <div class="col-sm-9">
+                                <label class="c-switch c-switch-label c-switch-pill c-switch-success fix-pill-form">
+                                    <input class="c-switch-input" type="checkbox" id="frmPassword-uppercaseLetter"
+                                        <%= global.passwordUppercaseLetter || '' %> <%= readOnly ? 'disabled' : '' %>>
+                                    <span class="c-switch-slider" data-checked="Yes" data-unchecked="No"></span>
+                                </label>
+                                <span class="form-text text-muted">
+                                    Should password must contain at least one UPPERCASE letter?
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Number</label>
+                            <div class="col-sm-9">
+                                <label class="c-switch c-switch-label c-switch-pill c-switch-success fix-pill-form">
+                                    <input class="c-switch-input" type="checkbox" id="frmPassword-number"
+                                        <%= global.passwordNumber || '' %> <%= readOnly ? 'disabled' : '' %>>
+                                    <span class="c-switch-slider" data-checked="Yes" data-unchecked="No"></span>
+                                </label>
+                                <span class="form-text text-muted">
+                                    Should password must contain at least one number?
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label class="col-sm-3 col-form-label">Special character</label>
+                            <div class="col-sm-9">
+                                <label class="c-switch c-switch-label c-switch-pill c-switch-success fix-pill-form">
+                                    <input class="c-switch-input" type="checkbox" id="frmPassword-specialCharacter"
+                                        <%= global.passwordSpecialCharacter || '' %> <%= readOnly ? 'disabled' : '' %>>
+                                    <span class="c-switch-slider" data-checked="Yes" data-unchecked="No"></span>
+                                </label>
+                                <span class="form-text text-muted">
+                                    Should password must contain at least one special character?
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="text-center mt-4">
+                            <button class="btn btn-sm btn-primary" type="submit" id="frmPassword-save" <%= readOnly ? 'disabled' : '' %>>
+                                <i class="icon-check"></i> Save Passwords Settings
+                            </button>
+                        </div>
+                    </div>
+                    <!-- /Passwords Tab -->
+
                 </div>
             </div>
 
@@ -748,4 +841,34 @@
         });
     });
 
+    //============================================== Password Settings
+
+    $('#frmPassword-save').click(function () {
+        let data = {
+            minLength: $('#frmPassword-minLength').val().trim(),
+            maxLength: $('#frmPassword-maxLength').val().trim(),
+            lowercaseLetter: ($('#frmPassword-lowercaseLetter').is(':checked') === true),
+            uppercaseLetter: ($('#frmPassword-uppercaseLetter').is(':checked') === true),
+            number: ($('#frmPassword-number').is(':checked') === true),
+            specialCharacter: ($('#frmPassword-specialCharacter').is(':checked') === true),
+        };
+        const notify = $.notify({ message: '<p class="text-center">Saving...</p>' }, {});
+
+        txAdminAPI({
+            type: "POST",
+            url: '/settings/save/password',
+            data: data,
+            dataType: 'json',
+            success: function (data) {
+                notify.update('progress', 0);
+                notify.update('type', data.type);
+                notify.update('message', data.message);
+            },
+            error: function (xmlhttprequest, textstatus, message) {
+                notify.update('progress', 0);
+                notify.update('type', 'danger');
+                notify.update('message', message);
+            }
+        });
+    });
 </script>


### PR DESCRIPTION
So basicly current you can use super insecure passwords like: password or something simmilar. Becuse there is only one validation - password length! So I decided to improve this a litte and first I only added more validation (one lowecase, one uppercase, one number and one special char). But later I think this not especialy good, so I added configuration for passwords to Settings tab. So now you can force using strong passwords to your server administrators and also don't need to use very complicated passwords for localhost purposes.