### PR TITLE
refactor(client/cl_player_ids): Add event for toggleing player ids

### DIFF
--- a/scripts/menu/client/cl_player_ids.lua
+++ b/scripts/menu/client/cl_player_ids.lua
@@ -98,6 +98,7 @@ local function togglePlayerIDsHandler()
         sendSnackbarMessage('info', 'nui_menu.page_main.player_ids.alert_show', true)
     end
 
+    TriggerServerEvent('txAdmin:events:togglePlayerIds', isPlayerIDActive)
     debugPrint('Show Player IDs Status: ' .. tostring(isPlayerIDActive))
 end
 


### PR DESCRIPTION
I am running an rp-server and I'd like to know whoever is using nametags currently, so admins won't abuse it in some situations. The trigger will be called from another script to print a simple message into the chat for all admins.