### PR TITLE
Added maxlength prop to confirmPassword input

### DIFF
--- a/web/parts/changePasswordModal.ejs
+++ b/web/parts/changePasswordModal.ejs
@@ -44,7 +44,7 @@
                         </label>
                         <div class="input-group">
                             <input type="password" autocomplete="new-password" class="form-control text-center"
-                                id="modChangePassword-confirmPassword">
+                                id="modChangePassword-confirmPassword" maxlength="24">
                         </div>
                     </div>
                     <div class="col-sm-12">


### PR DESCRIPTION
I've tried to enter a 60 characters long password and it was a bit buggy cause there was no maxLength to the "Confirm password" input so i've created this pull request.