### PR TITLE
feat(menu): players blips

### DIFF
--- a/locale/ar.json
+++ b/locale/ar.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle Player IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Showing nearby player NetIDs.",
-                "alert_hide": "Hiding nearby player NetIDs."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Showing nearby player NetIDs.",
+                    "alert_hide": "Hiding nearby player NetIDs."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/bg.json
+++ b/locale/bg.json
@@ -104,7 +104,7 @@
                     "label": "Копирай текущите координати."
                 }
             },
-            "vehicle":{
+            "vehicle": {
                 "title": "Автомобил",
                 "onesync_error": "Тази опция изисква 'OneSync' да е включен.",
                 "not_in_veh_error": "Не си в автомобил!",
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Покзване на ID-та",
-                "label": "Показване на ID-та на играчи (и други неща) над главите на играчите.",
-                "alert_show": "Покзване на ID-та в близост.",
-                "alert_hide": "Скриване на ID-та в близост."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Показване на ID-та на играчи (и други неща) над главите на играчите.",
+                    "alert_show": "Покзване на ID-та в близост.",
+                    "alert_hide": "Скриване на ID-та в близост."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/bs.json
+++ b/locale/bs.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle Player IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Showing nearby player NetIDs.",
-                "alert_hide": "Hiding nearby player NetIDs."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Showing nearby player NetIDs.",
+                    "alert_hide": "Hiding nearby player NetIDs."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/cs.json
+++ b/locale/cs.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Zapnout ID hráčů",
-                "label": "Zapnout ukazování ID hráčů (a další info) nad hlavou hráčů poblíž",
-                "alert_show": "Ukazuji ID hráčů poblíž.",
-                "alert_hide": "Skrývám ID hráčů poblíž."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Zapnout ukazování ID hráčů (a další info) nad hlavou hráčů poblíž",
+                    "alert_show": "Ukazuji ID hráčů poblíž.",
+                    "alert_hide": "Skrývám ID hráčů poblíž."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/da.json
+++ b/locale/da.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Vælg spiller-id'er",
-                "label": "Skift visning af spiller-id'er (og anden info) over hovedet på alle nærliggende spillere",
-                "alert_show": "Viser nærliggende spillerens NetID'er.",
-                "alert_hide": "Skjuler afspillerens NetID'er i nærheden."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Skift visning af spiller-id'er (og anden info) over hovedet på alle nærliggende spillere",
+                    "alert_show": "Viser nærliggende spillerens NetID'er.",
+                    "alert_hide": "Skjuler afspillerens NetID'er i nærheden."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/de.json
+++ b/locale/de.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Spieler IDs (NameTags)",
-                "label": "Schalte die Spieler-IDs (und weitere Informationen) über den Köpfen der Spieler ein oder aus.",
-                "alert_show": "Spieler IDs (NameTags) aktiviert.",
-                "alert_hide": "Spieler IDs (NameTags) deaktiviert."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Schalte die Spieler-IDs (und weitere Informationen) über den Köpfen der Spieler ein oder aus.",
+                    "alert_show": "Spieler IDs (NameTags) aktiviert.",
+                    "alert_hide": "Spieler IDs (NameTags) deaktiviert."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/el.json
+++ b/locale/el.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle Player IDs",
-                "label": "Εναλλαγή εμφάνισης αναγνωριστικών παικτών (και άλλων πληροφοριών) πάνω από το κεφάλι όλων των κοντινών παικτών",
-                "alert_show": "Εμφάνιση NetIDs των κοντινών παικτών.",
-                "alert_hide": "Εξαφάνηση NetIDs των κοντινών παικτών."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Εναλλαγή εμφάνισης αναγνωριστικών παικτών (και άλλων πληροφοριών) πάνω από το κεφάλι όλων των κοντινών παικτών",
+                    "alert_show": "Εμφάνιση NetIDs των κοντινών παικτών.",
+                    "alert_hide": "Εξαφάνηση NetIDs των κοντινών παικτών."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/en.json
+++ b/locale/en.json
@@ -159,10 +159,19 @@
                 "dialog_error": "Invalid radius input. Try again."
             },
             "player_ids": {
-                "title": "Toggle Player IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Showing nearby player NetIDs.",
-                "alert_hide": "Hiding nearby player NetIDs."
+                "title": "Players IDs",
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Showing nearby player NetIDs.",
+                    "alert_hide": "Hiding nearby player NetIDs."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/es.json
+++ b/locale/es.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Altenar IDs de jugadores",
-                "label": "Alternar el mostrar los IDs de jugadores (y otra información) sobre la cabeza de los jugadores cercanos",
-                "alert_show": "Enseñado NetIDs de jugadores cercanos.",
-                "alert_hide": "Ocultando NetIDs de jugadores cercanos."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Alternar el mostrar los IDs de jugadores (y otra información) sobre la cabeza de los jugadores cercanos",
+                    "alert_show": "Enseñado NetIDs de jugadores cercanos.",
+                    "alert_hide": "Ocultando NetIDs de jugadores cercanos."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/et.json
+++ b/locale/et.json
@@ -104,7 +104,7 @@
                     "label": "Kopeerige praegused maailma koordinaadid"
                 }
             },
-            "vehicle":{
+            "vehicle": {
                 "title": "Masinad",
                 "onesync_error": "See suvand nõuab, et OneSync oleks serveri olemi haldamiseks sisse lülitatud",
                 "not_in_veh_error": "Te ei ole praegu sõidukis!",
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Mängija ID sisse- ja väljalülitamine",
-                "label": "Lülitage mängija ID-de (ja muu teabe) kuvamine kõigi läheduses asuvate mängijate pea kohal",
-                "alert_show": "Kuvatakse lähedalasuvate mängijate NetID-d.",
-                "alert_hide": "Lähedal asuva mängija NetID-de peitmine."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Lülitage mängija ID-de (ja muu teabe) kuvamine kõigi läheduses asuvate mängijate pea kohal",
+                    "alert_show": "Kuvatakse lähedalasuvate mängijate NetID-d.",
+                    "alert_hide": "Lähedal asuva mängija NetID-de peitmine."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/fa.json
+++ b/locale/fa.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle Player IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Showing nearby player NetIDs.",
-                "alert_hide": "Hiding nearby player NetIDs."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Showing nearby player NetIDs.",
+                    "alert_hide": "Hiding nearby player NetIDs."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/fi.json
+++ b/locale/fi.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Näytä pelaajien ID:t",
-                "label": "Näytä lähellä olevien pelaajien ID:t",
-                "alert_show": "Näytetään lähellä olevien pelaajien ID:t.",
-                "alert_hide": "Piilotetaan lähellä olevien pelaajien ID:t."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Näytä lähellä olevien pelaajien ID:t",
+                    "alert_show": "Näytetään lähellä olevien pelaajien ID:t.",
+                    "alert_hide": "Piilotetaan lähellä olevien pelaajien ID:t."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Afficher les ID des joueurs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Les ID des joueurs sont affichés.",
-                "alert_hide": "Les ID des joueurs ne sont plus affichés."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Les ID des joueurs sont affichés.",
+                    "alert_hide": "Les ID des joueurs ne sont plus affichés."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/hu.json
+++ b/locale/hu.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "ID mód váltása",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Közeli játékosok ID-jének mutatása.",
-                "alert_hide": "Közeli játékosok ID-jének elrejtése."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Közeli játékosok ID-jének mutatása.",
+                    "alert_hide": "Közeli játékosok ID-jének elrejtése."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/it.json
+++ b/locale/it.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle ID dei Player",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Mostra gli ID dei player vicini.",
-                "alert_hide": "Nascondi gli ID dei player vicini."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Mostra gli ID dei player vicini.",
+                    "alert_hide": "Nascondi gli ID dei player vicini."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/lt.json
+++ b/locale/lt.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Žaidėjų ID rodymas",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Žaidėjų NetID rodomi.",
-                "alert_hide": "Žaidėjų NetID paslėpti."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Žaidėjų NetID rodomi.",
+                    "alert_hide": "Žaidėjų NetID paslėpti."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/lv.json
+++ b/locale/lv.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle Player IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Showing nearby player NetIDs.",
-                "alert_hide": "Hiding nearby player NetIDs."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Showing nearby player NetIDs.",
+                    "alert_hide": "Hiding nearby player NetIDs."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/nl.json
+++ b/locale/nl.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Schakel Speler IDs in/uit",
-                "label": "Schakel het tonen van Speler IDs (en andere info) boven de hoofden van alle spelers in jouw buurt in.",
-                "alert_show": "Toon de NetIDs van spelers in jouw buurt.",
-                "alert_hide": "Verberg NetIDs van spelers in jouw buurt."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Schakel het tonen van Speler IDs (en andere info) boven de hoofden van alle spelers in jouw buurt in.",
+                    "alert_show": "Toon de NetIDs van spelers in jouw buurt.",
+                    "alert_hide": "Verberg NetIDs van spelers in jouw buurt."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/no.json
+++ b/locale/no.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle Player IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Showing nearby player NetIDs.",
-                "alert_hide": "Hiding nearby player NetIDs."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Showing nearby player NetIDs.",
+                    "alert_hide": "Hiding nearby player NetIDs."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/pl.json
+++ b/locale/pl.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Przełącz ID graczy",
-                "label": "Przełącz pokazywanie ID graczy (i innych informacji) nad głowami pobliskich graczy",
-                "alert_show": "Pokazywanie NetID pobliskich graczy.",
-                "alert_hide": "Chowanie NetID pobliskich graczy."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Przełącz pokazywanie ID graczy (i innych informacji) nad głowami pobliskich graczy",
+                    "alert_show": "Pokazywanie NetID pobliskich graczy.",
+                    "alert_hide": "Chowanie NetID pobliskich graczy."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Mostrar/Esconder IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Mostrando os NetIDs próximos.",
-                "alert_hide": "Escondendo os NetIDs próximos."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Mostrando os NetIDs próximos.",
+                    "alert_hide": "Escondendo os NetIDs próximos."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/ro.json
+++ b/locale/ro.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Comută ID-urile jucătorilor",
-                "label": "Comutarea afișării ID-urilor jucătorilor deasupra capului tuturor jucătorilor din apropiere",
-                "alert_show": "Afișarea NetID-urilor jucătorilor din apropiere.",
-                "alert_hide": "Ascunderea NetID-urilor jucătorilor din apropiere."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Comutarea afișării ID-urilor jucătorilor deasupra capului tuturor jucătorilor din apropiere",
+                    "alert_show": "Afișarea NetID-urilor jucătorilor din apropiere.",
+                    "alert_hide": "Ascunderea NetID-urilor jucătorilor din apropiere."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Переключать идентификаторы игроков",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Отображаются сетевые идентификаторы ближайших игроков.",
-                "alert_hide": "Скрытие идентификаторов ближайших игроков в сети."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Отображаются сетевые идентификаторы ближайших игроков.",
+                    "alert_hide": "Скрытие идентификаторов ближайших игроков в сети."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/sl.json
+++ b/locale/sl.json
@@ -104,7 +104,7 @@
                     "label": "Kopiraj trenutne koordinate v odložišče"
                 }
             },
-            "vehicle":{
+            "vehicle": {
                 "title": "Vozila",
                 "onesync_error": "Ta možnost zahteva, da je OneSync vklopljen za ravnanje s »entity handling«",
                 "not_in_veh_error": "Trenutno nisi v vozilu!",
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Prižgi IDje igralcev",
-                "label": "Prižgani IDji igralcev (in ostale informacije) nad glavo vseh bližnjih igralcev",
-                "alert_show": "IDji bližnjih igralcev vklopljeni.",
-                "alert_hide": "IDji bližnjih igralcev izklopljeni."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Prižgani IDji igralcev (in ostale informacije) nad glavo vseh bližnjih igralcev",
+                    "alert_show": "IDji bližnjih igralcev vklopljeni.",
+                    "alert_hide": "IDji bližnjih igralcev izklopljeni."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Sätt på spelares id",
-                "label": "När du sätter på detta kommer du kunna se alla spelares id i närheten.",
-                "alert_show": "Visa spelares id i närheten.",
-                "alert_hide": "Dölj spelares id i närheten."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "När du sätter på detta kommer du kunna se alla spelares id i närheten.",
+                    "alert_show": "Visa spelares id i närheten.",
+                    "alert_hide": "Dölj spelares id i närheten."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/th.json
+++ b/locale/th.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "สลับไอดีผู้เล่น",
-                "label": "สลับการแสดงไอดีผู้เล่น (และข้อมูลอื่นๆ) บริเวณส่วนเหนือหัวของผู้เล่นในระยะใกล้เคียงทั้งหมด",
-                "alert_show": "กำลังแสดงไอดีของผู้เล่นใกล้เคียง",
-                "alert_hide": "กำลังซ่อนไอดีของผู้เล่นใกล้เคียง"
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "สลับการแสดงไอดีผู้เล่น (และข้อมูลอื่นๆ) บริเวณส่วนเหนือหัวของผู้เล่นในระยะใกล้เคียงทั้งหมด",
+                    "alert_show": "กำลังแสดงไอดีของผู้เล่นใกล้เคียง",
+                    "alert_hide": "กำลังซ่อนไอดีของผู้เล่นใกล้เคียง"
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/tr.json
+++ b/locale/tr.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle Player IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Showing nearby player NetIDs.",
-                "alert_hide": "Hiding nearby player NetIDs."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Showing nearby player NetIDs.",
+                    "alert_hide": "Hiding nearby player NetIDs."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -160,9 +160,18 @@
             },
             "player_ids": {
                 "title": "Toggle Player IDs",
-                "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
-                "alert_show": "Showing nearby player NetIDs.",
-                "alert_hide": "Hiding nearby player NetIDs."
+                "above_head": {
+                    "name": "Over Head IDs",
+                    "label": "Toggle showing player IDs (and other info) above the head of all nearby players",
+                    "alert_show": "Showing nearby player NetIDs.",
+                    "alert_hide": "Hiding nearby player NetIDs."
+                },
+                "map_blips": {
+                    "name": "Blips on map",
+                    "label": "Toggle players blips on map as well as their NetIDs.",
+                    "alert_show": "Showing players blips on map.",
+                    "alert_hide": "Hiding players blips on map."
+                }
             }
         },
         "page_players": {

--- a/nui/src/components/MainPage/MainPageList.tsx
+++ b/nui/src/components/MainPage/MainPageList.tsx
@@ -18,6 +18,7 @@ import {
   Restore,
   Security,
   DeleteForever,
+  TrackChanges
   // Stream //Spawn Weapon action
 } from "@mui/icons-material";
 import { useKeyboardNavigation } from "../../hooks/useKeyboardNavigation";
@@ -33,6 +34,7 @@ import { arrayRandom } from "../../utils/miscUtils";
 import { copyToClipboard } from "../../utils/copyToClipboard";
 import { useServerCtxValue } from "../../state/server.state";
 import { VehicleMode, useVehicleMode } from "../../state/vehiclemode.state";
+import { PlayerIDsMode, usePlayerIdsMode } from "../../state/playerids.state";
 
 const fadeHeight = 20;
 const listHeight = 388;
@@ -76,6 +78,7 @@ export const MainPageList: React.FC = () => {
   const [teleportMode, setTeleportMode] = useTeleportMode();
   const [vehicleMode, setVehicleMode] = useVehicleMode();
   const [healMode, setHealMode] = useHealMode();
+  const [playerIdsMode, setPlayerIdsMode] = usePlayerIdsMode();
   const serverCtx = useServerCtxValue();
   const menuVisible = useIsMenuVisibleValue();
 
@@ -353,6 +356,10 @@ export const MainPageList: React.FC = () => {
     fetchNui("togglePlayerIDs");
   };
 
+  const handleToggleMapBlips = () => {
+    fetchNui("togglePlayerMapBlips");
+  };
+
   // This is here for when I am bored developing
   // const handleSpawnWeapon = () => {
   //   openDialog({
@@ -538,10 +545,31 @@ export const MainPageList: React.FC = () => {
       },
       {
         title: t("nui_menu.page_main.player_ids.title"),
-        label: t("nui_menu.page_main.player_ids.label"),
+        isMultiAction: true,
         requiredPermission: "menu.viewids",
-        icon: <Groups />,
-        onSelect: handleTogglePlayerIds,
+        initialValue: playerIdsMode,
+        actions: [
+          {
+            name: t("nui_menu.page_main.player_ids.above_head.name"),
+            label: t("nui_menu.page_main.player_ids.above_head.label"),
+            icon: <Groups />,
+            value: PlayerIDsMode.ABOVE,
+            onSelect: () => {
+              setPlayerIdsMode(PlayerIDsMode.ABOVE)
+              handleTogglePlayerIds()
+            }
+          },
+          {
+            name: t("nui_menu.page_main.player_ids.map_blips.name"),
+            label: t("nui_menu.page_main.player_ids.map_blips.label"),
+            icon: <TrackChanges />,
+            value: PlayerIDsMode.MAP,
+            onSelect: () => {
+              setPlayerIdsMode(PlayerIDsMode.MAP)
+              handleToggleMapBlips()
+            }
+          }
+        ],
       },
       // {
       //   title: "Spawn Weapon",
@@ -549,7 +577,7 @@ export const MainPageList: React.FC = () => {
       //   onSelect: handleSpawnWeapon,
       // },
     ],
-    [playerMode, teleportMode, vehicleMode, healMode, serverCtx]
+    [playerMode, teleportMode, vehicleMode, healMode, serverCtx, playerIdsMode]
   );
 
   return (

--- a/nui/src/state/playerids.state.ts
+++ b/nui/src/state/playerids.state.ts
@@ -1,0 +1,13 @@
+import { atom, useRecoilState } from "recoil";
+
+export enum PlayerIDsMode {
+  ABOVE,
+  MAP,
+}
+
+const playerIds = atom({
+  key: "playerIdsState",
+  default: PlayerIDsMode.ABOVE,
+});
+
+export const usePlayerIdsMode = () => useRecoilState(playerIds);

--- a/resource/cl_main.lua
+++ b/resource/cl_main.lua
@@ -93,6 +93,7 @@ CreateThread(function()
     TriggerEvent('chat:removeSuggestion', '/txAdmin:menu:endSpectate')
     TriggerEvent('chat:removeSuggestion', '/txAdmin:menu:openPlayersPage')
     TriggerEvent('chat:removeSuggestion', '/txAdmin:menu:togglePlayerIDs')
+    TriggerEvent('chat:removeSuggestion', '/txAdmin:menu:togglePlayerMapBlips')
 
     --Convars
     TriggerEvent('chat:removeSuggestion', '/txAdmin-version')

--- a/resource/menu/client/cl_base.lua
+++ b/resource/menu/client/cl_base.lua
@@ -77,6 +77,7 @@ RegisterNetEvent('txcl:setAdmin', function(username, perms, rejectReason)
     RegisterKeyMapping('txAdmin:menu:openPlayersPage', 'Menu: Open Players page', 'KEYBOARD', '')
     RegisterKeyMapping('txAdmin:menu:noClipToggle', 'Menu: Toggle NoClip', 'keyboard', '')
     RegisterKeyMapping('txAdmin:menu:togglePlayerIDs', 'Menu: Toggle Player IDs', 'KEYBOARD', '')
+    RegisterKeyMapping('txAdmin:menu:togglePlayerMapBlips', 'Menu: Toggle Player Map Blips', 'KEYBOARD', '')
     RegisterKeyMapping('txAdmin:menu:endSpectate', 'Menu: Exit spectate mode', 'keyboard', 'BACK')
   else
     print("^3[AUTH] rejected (" .. tostring(rejectReason) ..")")

--- a/resource/menu/client/cl_player_ids.lua
+++ b/resource/menu/client/cl_player_ids.lua
@@ -91,11 +91,11 @@ local function showPlayerIDs(enabled)
 
     isPlayerIDActive = enabled
     if not isPlayerIDActive then
-        sendSnackbarMessage('info', 'nui_menu.page_main.player_ids.alert_hide', true)
+        sendSnackbarMessage('info', 'nui_menu.page_main.player_ids.above_head.alert_hide', true)
         -- Remove all gamer tags and clear out active table
         cleanUpGamerTags()
     else
-        sendSnackbarMessage('info', 'nui_menu.page_main.player_ids.alert_show', true)
+        sendSnackbarMessage('info', 'nui_menu.page_main.player_ids.above_head.alert_show', true)
     end
 
     debugPrint('Show Player IDs Status: ' .. tostring(isPlayerIDActive))
@@ -116,6 +116,55 @@ RegisterNUICallback('togglePlayerIDs', function(_, cb)
 end)
 
 RegisterCommand('txAdmin:menu:togglePlayerIDs', togglePlayerIDsHandler)
+
+local playersBlips = {}
+---Refreshes blips on client
+---@param blipsData {[string]: {coords: {x:number,y:number,z:number,h:number}, name:string}}
+local function refreshPlayerBlips(blipsData)
+    for k, v in pairs(playersBlips) do
+        RemoveBlip(v)
+      end
+      playersBlips = {}
+      for playerId, v in pairs(blipsData) do
+        local blip = AddBlipForCoord(v.coords.x+0.01, v.coords.y+0.01, v.coords.z+0.01)
+        playersBlips[playerId] = blip
+        SetBlipShrink(blip, true)
+        SetBlipCategory(blip, 7)
+        SetBlipSprite(blip, 1)
+        SetBlipDisplay(blip, 4)
+        SetBlipScale(blip, 0.87)
+        SetBlipColour(blip, 2)
+        SetBlipFlashes(blip, false)
+        SetBlipRotation(blip, math.ceil(v.coords.h))
+        ShowNumberOnBlip(blip, playerId)
+        ShowHeadingIndicatorOnBlip(blip, true)
+        BeginTextCommandSetBlipName('STRING')
+        AddTextComponentString(v.name)
+        EndTextCommandSetBlipName(blip)
+      end
+end
+
+RegisterNetEvent('txAdmin:menu:refreshPlayerBlips', function(blipsData, enabled)
+    debugPrint('Received refreshPlayerBlips event')
+    refreshPlayerBlips(blipsData)
+    if enabled == nil then return end
+    if enabled then
+        sendSnackbarMessage('info', 'nui_menu.page_main.player_ids.map_blips.alert_show', true)
+    else
+        sendSnackbarMessage('info', 'nui_menu.page_main.player_ids.map_blips.alert_hide', true)
+    end
+end)
+
+local function togglePlayerMapBlipsHandler()
+    TriggerServerEvent('txAdmin:menu:showPlayerMapBlips', not isPlayerIDActive)
+end
+
+RegisterNUICallback('togglePlayerMapBlips', function(_, cb)
+    togglePlayerMapBlipsHandler()
+    cb({})
+end)
+
+RegisterCommand('txAdmin:menu:togglePlayerMapBlips', togglePlayerMapBlipsHandler)
 
 CreateThread(function()
     local sleep = 150

--- a/resource/menu/client/cl_player_ids.lua
+++ b/resource/menu/client/cl_player_ids.lua
@@ -136,10 +136,10 @@ local function refreshPlayerBlips(blipsData)
         SetBlipColour(blip, 2)
         SetBlipFlashes(blip, false)
         SetBlipRotation(blip, math.ceil(v.coords.h))
-        ShowNumberOnBlip(blip, playerId)
+        ShowNumberOnBlip(blip, tonumber(playerId % 100)) -- If blip number is above 100 it won't show anything
         ShowHeadingIndicatorOnBlip(blip, true)
         BeginTextCommandSetBlipName('STRING')
-        AddTextComponentString(v.name)
+        AddTextComponentString(('%s [%s]'):format(v.name, playerId))
         EndTextCommandSetBlipName(blip)
       end
 end

--- a/resource/sv_logger.lua
+++ b/resource/sv_logger.lua
@@ -206,6 +206,13 @@ AddEventHandler('txaLogger:menuEvent', function(source, event, allowed, data)
         else
             message = "turned show player IDs off"
         end
+    elseif event == 'showPlayerMapBlips' then
+        if type(data) ~= 'boolean' then return end
+        if data then
+            message = "turned show player map blips on"
+        else
+            message = "turned show player map blips off"
+        end
 
     --In case of unknown event
     else


### PR DESCRIPTION
Feature:
Menu option to disply players blips on map, coords fetched server side, so all players will be displayed no matter if onesync is on or off.

![image](https://user-images.githubusercontent.com/63473480/189482880-b6f377c4-2e64-449d-a280-bb18b1ff93f6.png)
![image](https://user-images.githubusercontent.com/63473480/189482891-62f1226c-c41b-4b8a-8144-010de4596ffb.png)
