### PR TITLE
fix(nui/vite): bypass fxserver file checks when using nui dev script for browser 

### DIFF
--- a/nui/vite.config.ts
+++ b/nui/vite.config.ts
@@ -37,6 +37,11 @@ const baseConfig = {
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
+    if (mode === 'devNuiBrowser') {
+        console.log('Launching NUI in browser mode')
+        return baseConfig
+    }
+
     if (mode === 'development') {
         let devDeplyPath;
         try {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:menu": "vite build nui/ --mode production",
     "build:main": "node scripts/main-builder.js publish",
     "prepare": "husky install",
-    "dev:menu:browser": "vite dev nui/",
+    "dev:menu:browser": "vite dev nui/ --mode devNuiBrowser",
     "dev:menu:game": "vite build nui/ --watch --mode development",
     "dev:main": "node scripts/main-builder.js dev",
     "typecheck": "npm run typecheck:menu && npm run typecheck:main",


### PR DESCRIPTION
# Summary

Bypasses pre-start FXServer location check within the NUI Vite config when starting with the mode "devMenuBrowser".