### PR TITLE
fix(menu/player-modal): resolve loading issues & state refactor

### DIFF
--- a/nui/src/components/PlayerModal/PlayerModal.tsx
+++ b/nui/src/components/PlayerModal/PlayerModal.tsx
@@ -1,33 +1,38 @@
 import {
   Box,
-  Dialog,
-  DialogTitle,
-  List,
-  ListItem,
-  ListItemText,
-  useTheme,
-  IconButton,
-  ListItemIcon,
   CircularProgress,
+  DialogTitle,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
 } from "@mui/material";
-import { styled } from '@mui/material/styles';
+import { styled } from "@mui/material/styles";
 import {
-  Close,
-  Person,
   Block,
+  Close,
+  FlashOn,
   FormatListBulleted,
   MenuBook,
-  FlashOn,
+  Person,
 } from "@mui/icons-material";
-import { usePlayerModalContext } from "../../provider/PlayerModalProvider";
-import { useAssociatedPlayerValue, usePlayerDetailsValue } from "../../state/playerDetails.state";
+import {
+  useAssociatedPlayerValue,
+  usePlayerDetailsValue,
+} from "../../state/playerDetails.state";
 import { useTranslate } from "react-polyglot";
 import { DialogBaseView } from "./Tabs/DialogBaseView";
 import { PlayerModalErrorBoundary } from "./ErrorHandling/PlayerModalErrorBoundary";
 import { usePermissionsValue } from "../../state/permissions.state";
 import { userHasPerm } from "../../utils/miscUtils";
 import React from "react";
-
+import {
+  PlayerModalTabs,
+  usePlayerModalTabValue,
+  useSetPlayerModalTab,
+  useSetPlayerModalVisibility,
+} from "@nui/src/state/playerModal.state";
 
 const classes = {
   listItem: `PlayerModal-listItem`,
@@ -37,17 +42,17 @@ const classes = {
 const StyledList = styled(List)(({ theme }) => ({
   [`& .${classes.listItem}`]: {
     borderRadius: 8,
-    '&.Mui-selected:hover': {
+    "&.Mui-selected:hover": {
       backgroundColor: "rgba(255, 255, 255, 0.08)",
     },
   },
 
   [`& .${classes.listItemBan}`]: {
     borderRadius: 8,
-    '&:hover, &.Mui-selected': {
+    "&:hover, &.Mui-selected": {
       background: theme.palette.error.main,
     },
-    '&.Mui-selected:hover': {
+    "&.Mui-selected:hover": {
       backgroundColor: "rgba(194,13,37, 0.8)",
     },
   },
@@ -72,10 +77,9 @@ const StyledCloseButton = styled(IconButton)(({ theme }) => ({
 }));
 
 const PlayerModal: React.FC = () => {
-  const { setModalOpen, isModalOpen } = usePlayerModalContext();
+  const setModalOpen = useSetPlayerModalVisibility();
   const playerDetails = usePlayerDetailsValue();
   const assocPlayer = useAssociatedPlayerValue();
-  const theme = useTheme();
 
   const handleClose = () => {
     setModalOpen(false);
@@ -86,39 +90,32 @@ const PlayerModal: React.FC = () => {
   const error = (playerDetails as any).error;
 
   return (
-    <Dialog
-      open={isModalOpen}
-      fullWidth
-      onClose={handleClose}
-      maxWidth="md"
-      PaperProps={{
-        style: {
-          backgroundColor: theme.palette.background.default,
-          minHeight: 450,
-          maxHeight: 650,
-          borderRadius: 15,
-        },
-        id: "player-modal-container",
-      }}
-    >
+    <>
       <DialogTitle style={{ borderBottom: "1px solid rgba(221,221,221,0.54)" }}>
-        [{assocPlayer.id}] {playerDetails?.player?.displayName ?? assocPlayer.name}
+        [{assocPlayer.id}]{" "}
+        {playerDetails?.player?.displayName ?? assocPlayer.name}
         <StyledCloseButton onClick={handleClose} size="large">
           <Close />
         </StyledCloseButton>
       </DialogTitle>
       <Box display="flex" px={2} pb={2} pt={2} flexGrow={1} overflow="hidden">
         <PlayerModalErrorBoundary>
-          {error ? <>
-            <h2 style={{
-              marginLeft: 'auto',
-              marginRight: 'auto',
-              textAlign: 'center',
-              fontWeight: '500',
-              maxWidth: '70%',
-              paddingTop: '2em'
-            }}>{error}</h2>
-          </> :
+          {error ? (
+            <>
+              <h2
+                style={{
+                  marginLeft: "auto",
+                  marginRight: "auto",
+                  textAlign: "center",
+                  fontWeight: "500",
+                  maxWidth: "70%",
+                  paddingTop: "2em",
+                }}
+              >
+                {error}
+              </h2>
+            </>
+          ) : (
             <>
               <Box
                 minWidth={200}
@@ -131,76 +128,86 @@ const PlayerModal: React.FC = () => {
                 <DialogBaseView />
               </React.Suspense>
             </>
-          }
+          )}
         </PlayerModalErrorBoundary>
       </Box>
-    </Dialog>
+    </>
+  );
+};
+
+interface DialogTabProps {
+  title: string;
+  tab: PlayerModalTabs;
+  curTab: PlayerModalTabs;
+  icon: JSX.Element;
+  isDisabled?: boolean;
+}
+
+const DialogTab: React.FC<DialogTabProps> = ({
+  isDisabled,
+  curTab,
+  tab,
+  icon,
+  title,
+}) => {
+  const setTab = useSetPlayerModalTab();
+
+  const stylingClass =
+    tab === PlayerModalTabs.BAN ? classes.listItemBan : classes.listItem;
+
+  const isSelected = curTab === tab;
+
+  return (
+    <ListItemButton
+      className={stylingClass}
+      selected={isSelected}
+      onClick={() => setTab(tab)}
+      disabled={isDisabled}
+    >
+      <ListItemIcon>{icon}</ListItemIcon>
+      <ListItemText primary={title} />
+    </ListItemButton>
   );
 };
 
 const DialogList: React.FC = () => {
-  const { tab, setTab } = usePlayerModalContext();
+  const curTab = usePlayerModalTabValue();
   const t = useTranslate();
   const playerPerms = usePermissionsValue();
 
   return (
     <StyledList>
-      <ListItem
-        className={classes.listItem}
-        button
-        onClick={() => setTab(1)}
-        selected={tab === 1}
-      >
-        <ListItemIcon>
-          <FlashOn />
-        </ListItemIcon>
-        <ListItemText primary={t("nui_menu.player_modal.tabs.actions")} />
-      </ListItem>
-      <ListItem
-        className={classes.listItem}
-        button
-        onClick={() => setTab(2)}
-        selected={tab === 2}
-      >
-        <ListItemIcon>
-          <Person />
-        </ListItemIcon>
-        <ListItemText primary={t("nui_menu.player_modal.tabs.info")} />
-      </ListItem>
-      <ListItem
-        className={classes.listItem}
-        button
-        onClick={() => setTab(3)}
-        selected={tab === 3}
-      >
-        <ListItemIcon>
-          <FormatListBulleted />
-        </ListItemIcon>
-        <ListItemText primary={t("nui_menu.player_modal.tabs.ids")} />
-      </ListItem>
-      <ListItem
-        className={classes.listItem}
-        button
-        onClick={() => setTab(4)}
-        selected={tab === 4}
-      >
-        <ListItemIcon>
-          <MenuBook />
-        </ListItemIcon>
-        <ListItemText primary={t("nui_menu.player_modal.tabs.history")} />
-      </ListItem>
-      <ListItem
-        className={classes.listItemBan}
-        button
-        disabled={!userHasPerm("players.ban", playerPerms)}
-        onClick={() => setTab(5)}
-        selected={tab === 5}
-      >
-        <ListItemIcon>
-          <Block />
-        </ListItemIcon>
-        <ListItemText primary={t("nui_menu.player_modal.tabs.ban")} />
-      </ListItem>
+      <DialogTab
+        title={t("nui_menu.player_modal.tabs.actions")}
+        tab={PlayerModalTabs.ACTIONS}
+        curTab={curTab}
+        icon={<FlashOn />}
+      />
+      <DialogTab
+        title={t("nui_menu.player_modal.tabs.info")}
+        tab={PlayerModalTabs.INFO}
+        curTab={curTab}
+        icon={<Person />}
+      />
+      <DialogTab
+        title={t("nui_menu.player_modal.tabs.ids")}
+        tab={PlayerModalTabs.IDENTIFIERS}
+        curTab={curTab}
+        icon={<FormatListBulleted />}
+      />
+      <DialogTab
+        title={t("nui_menu.player_modal.tabs.history")}
+        tab={PlayerModalTabs.HISTORY}
+        curTab={curTab}
+        icon={<MenuBook />}
+      />
+      <DialogTab
+        title={t("nui_menu.player_modal.tabs.ban")}
+        tab={PlayerModalTabs.BAN}
+        curTab={curTab}
+        icon={<Block />}
+        isDisabled={!userHasPerm("players.ban", playerPerms)}
+      />
     </StyledList>
   );
 };

--- a/nui/src/components/PlayerModal/Tabs/DialogActionView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogActionView.tsx
@@ -1,6 +1,13 @@
 import React from "react";
-import { styled } from '@mui/material/styles';
-import { Box, Button, DialogContent, Tooltip, TooltipProps, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import {
+  Box,
+  Button,
+  DialogContent,
+  Tooltip,
+  TooltipProps,
+  Typography,
+} from "@mui/material";
 import {
   useAssociatedPlayerValue,
   usePlayerDetailsValue,
@@ -16,13 +23,14 @@ import { useTranslate } from "react-polyglot";
 import { usePermissionsValue } from "../../../state/permissions.state";
 import { DialogLoadError } from "./DialogLoadError";
 import { GenericApiError, GenericApiResp } from "@shared/genericApiTypes";
+import { useSetPlayerModalVisibility } from "@nui/src/state/playerModal.state";
 
-const PREFIX = 'DialogActionView';
+const PREFIX = "DialogActionView";
 
 const classes = {
   actionGrid: `${PREFIX}-actionGrid`,
   tooltipOverride: `${PREFIX}-tooltipOverride`,
-  sectionTitle: `${PREFIX}-sectionTitle`
+  sectionTitle: `${PREFIX}-sectionTitle`,
 };
 
 const StyledDialogContent = styled(DialogContent)({
@@ -55,23 +63,26 @@ const DialogActionView: React.FC = () => {
   const t = useTranslate();
   const { goToFramePage } = useIFrameCtx();
   const playerPerms = usePermissionsValue();
-  const { setModalOpen, closeMenu, showNoPerms } = usePlayerModalContext();
-  if ('error' in playerDetails) return (<DialogLoadError />);
+  const setModalOpen = useSetPlayerModalVisibility();
+  const { closeMenu, showNoPerms } = usePlayerModalContext();
+  if ("error" in playerDetails) return <DialogLoadError />;
 
   //Helper
-  const handleGenericApiResponse = (result: GenericApiResp, successMessageKey: string) => {
-    if('success' in result && result.success === true){
-      enqueueSnackbar(
-        t(`nui_menu.player_modal.actions.${successMessageKey}`),
-        { variant: 'success' }
-      );
-    }else{
+  const handleGenericApiResponse = (
+    result: GenericApiResp,
+    successMessageKey: string
+  ) => {
+    if ("success" in result && result.success === true) {
+      enqueueSnackbar(t(`nui_menu.player_modal.actions.${successMessageKey}`), {
+        variant: "success",
+      });
+    } else {
       enqueueSnackbar(
         (result as GenericApiError).error ?? t("nui_menu.misc.unknown_error"),
-        { variant: 'error' }
+        { variant: "error" }
       );
     }
-  }
+  };
 
   //Moderation
   const handleDM = () => {
@@ -90,13 +101,16 @@ const DialogActionView: React.FC = () => {
       ),
       onSubmit: async (message: string) => {
         try {
-          const result = await fetchWebPipe<GenericApiResp>(`/player/message?mutex=current&netid=${assocPlayer.id}`, {
-            method: "POST",
-            data: { message: message.trim() },
-          });
-          handleGenericApiResponse(result, 'moderation.dm_dialog.success');
+          const result = await fetchWebPipe<GenericApiResp>(
+            `/player/message?mutex=current&netid=${assocPlayer.id}`,
+            {
+              method: "POST",
+              data: { message: message.trim() },
+            }
+          );
+          handleGenericApiResponse(result, "moderation.dm_dialog.success");
         } catch (error) {
-          enqueueSnackbar((error as Error).message, { variant: 'error' });
+          enqueueSnackbar((error as Error).message, { variant: "error" });
         }
       },
     });
@@ -117,13 +131,16 @@ const DialogActionView: React.FC = () => {
       ),
       onSubmit: async (reason: string) => {
         try {
-          const result = await fetchWebPipe<GenericApiResp>(`/player/warn?mutex=current&netid=${assocPlayer.id}`, {
-            method: "POST",
-            data: { reason: reason.trim() },
-          });
-          handleGenericApiResponse(result, 'moderation.warn_dialog.success');
+          const result = await fetchWebPipe<GenericApiResp>(
+            `/player/warn?mutex=current&netid=${assocPlayer.id}`,
+            {
+              method: "POST",
+              data: { reason: reason.trim() },
+            }
+          );
+          handleGenericApiResponse(result, "moderation.warn_dialog.success");
         } catch (error) {
-          enqueueSnackbar((error as Error).message, { variant: 'error' });
+          enqueueSnackbar((error as Error).message, { variant: "error" });
         }
       },
     });
@@ -144,13 +161,16 @@ const DialogActionView: React.FC = () => {
       ),
       onSubmit: async (reason: string) => {
         try {
-          const result = await fetchWebPipe<GenericApiResp>(`/player/kick?mutex=current&netid=${assocPlayer.id}`, {
-            method: "POST",
-            data: { reason: reason.trim() },
-          });
-          handleGenericApiResponse(result, 'moderation.kick_dialog.success');
+          const result = await fetchWebPipe<GenericApiResp>(
+            `/player/kick?mutex=current&netid=${assocPlayer.id}`,
+            {
+              method: "POST",
+              data: { reason: reason.trim() },
+            }
+          );
+          handleGenericApiResponse(result, "moderation.kick_dialog.success");
         } catch (error) {
-          enqueueSnackbar((error as Error).message, { variant: 'error' });
+          enqueueSnackbar((error as Error).message, { variant: "error" });
         }
       },
     });
@@ -162,15 +182,15 @@ const DialogActionView: React.FC = () => {
     }
     //If the playerDetails is available
     const params = new URLSearchParams();
-    if (typeof playerDetails.player.netid === 'number') {
-      params.set('autofill', 'true');
-      params.set('name', playerDetails.player.pureName);
+    if (typeof playerDetails.player.netid === "number") {
+      params.set("autofill", "true");
+      params.set("name", playerDetails.player.pureName);
 
       for (const id of playerDetails.player.ids) {
-        if (id.startsWith('discord:')) {
-          params.set('discord', id);
-        } else if (id.startsWith('fivem:')) {
-          params.set('citizenfx', id);
+        if (id.startsWith("discord:")) {
+          params.set("discord", id);
+        } else if (id.startsWith("fivem:")) {
+          params.set("citizenfx", id);
         }
       }
     }
@@ -186,9 +206,7 @@ const DialogActionView: React.FC = () => {
 
     fetchNui("healPlayer", { id: assocPlayer.id });
     enqueueSnackbar(
-      t(
-        "nui_menu.player_modal.actions.interaction.notifications.heal_player"
-      ),
+      t("nui_menu.player_modal.actions.interaction.notifications.heal_player"),
       { variant: "success" }
     );
   };
@@ -200,9 +218,7 @@ const DialogActionView: React.FC = () => {
     closeMenu();
     fetchNui("tpToPlayer", { id: assocPlayer.id });
     enqueueSnackbar(
-      t(
-        "nui_menu.player_modal.actions.interaction.notifications.tp_player"
-      ),
+      t("nui_menu.player_modal.actions.interaction.notifications.tp_player"),
       { variant: "success" }
     );
   };
@@ -214,9 +230,7 @@ const DialogActionView: React.FC = () => {
     closeMenu();
     fetchNui("summonPlayer", { id: assocPlayer.id });
     enqueueSnackbar(
-      t(
-        "nui_menu.player_modal.actions.interaction.notifications.bring_player"
-      ),
+      t("nui_menu.player_modal.actions.interaction.notifications.bring_player"),
       { variant: "success" }
     );
   };
@@ -233,7 +247,7 @@ const DialogActionView: React.FC = () => {
     if (!userHasPerm("players.freeze", playerPerms))
       return showNoPerms("Freeze");
     fetchNui("togglePlayerFreeze", { id: assocPlayer.id });
-  }
+  };
 
   //Troll
   const handleDrunk = () => {
@@ -276,16 +290,36 @@ const DialogActionView: React.FC = () => {
         {t("nui_menu.player_modal.actions.moderation.title")}
       </Typography>
       <Box className={classes.actionGrid}>
-        <Button variant="outlined" color="primary" onClick={handleDM} disabled={!userHasPerm("players.message", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleDM}
+          disabled={!userHasPerm("players.message", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.moderation.options.dm")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleWarn} disabled={!userHasPerm("players.warn", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleWarn}
+          disabled={!userHasPerm("players.warn", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.moderation.options.warn")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleKick} disabled={!userHasPerm("players.kick", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleKick}
+          disabled={!userHasPerm("players.kick", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.moderation.options.kick")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleSetAdmin} disabled={!userHasPerm("manage.admins", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleSetAdmin}
+          disabled={!userHasPerm("manage.admins", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.moderation.options.set_admin")}
         </Button>
       </Box>
@@ -293,19 +327,44 @@ const DialogActionView: React.FC = () => {
         {t("nui_menu.player_modal.actions.interaction.title")}
       </Typography>
       <Box className={classes.actionGrid}>
-        <Button variant="outlined" color="primary" onClick={handleHeal} disabled={!userHasPerm("players.heal", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleHeal}
+          disabled={!userHasPerm("players.heal", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.interaction.options.heal")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleGoTo} disabled={!userHasPerm("players.teleport", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleGoTo}
+          disabled={!userHasPerm("players.teleport", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.interaction.options.go_to")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleBring} disabled={!userHasPerm("players.teleport", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleBring}
+          disabled={!userHasPerm("players.teleport", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.interaction.options.bring")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleSpectate} disabled={!userHasPerm("players.spectate", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleSpectate}
+          disabled={!userHasPerm("players.spectate", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.interaction.options.spectate")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleFreeze} disabled={!userHasPerm("players.freeze", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleFreeze}
+          disabled={!userHasPerm("players.freeze", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.interaction.options.toggle_freeze")}
         </Button>
       </Box>
@@ -313,13 +372,28 @@ const DialogActionView: React.FC = () => {
         {t("nui_menu.player_modal.actions.troll.title")}
       </Typography>
       <Box className={classes.actionGrid}>
-        <Button variant="outlined" color="primary" onClick={handleDrunk} disabled={!userHasPerm("players.troll", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleDrunk}
+          disabled={!userHasPerm("players.troll", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.troll.options.drunk")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleSetOnFire} disabled={!userHasPerm("players.troll", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleSetOnFire}
+          disabled={!userHasPerm("players.troll", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.troll.options.fire")}
         </Button>
-        <Button variant="outlined" color="primary" onClick={handleWildAttack} disabled={!userHasPerm("players.troll", playerPerms)}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleWildAttack}
+          disabled={!userHasPerm("players.troll", playerPerms)}
+        >
           {t("nui_menu.player_modal.actions.troll.options.wild_attack")}
         </Button>
       </Box>

--- a/nui/src/components/PlayerModal/Tabs/DialogBaseView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogBaseView.tsx
@@ -4,19 +4,30 @@ import DialogInfoView from "./DialogInfoView";
 import DialogIdView from "./DialogIdView";
 import DialogHistoryView from "./DialogHistoryView";
 import DialogBanView from "./DialogBanView";
-import { Box } from "@mui/material";
-import { usePlayerModalContext } from "../../../provider/PlayerModalProvider";
+import {Box} from "@mui/material";
+import {PlayerModalTabs, usePlayerModalTabValue} from "@nui/src/state/playerModal.state";
+
+const tabToRender = (tab: PlayerModalTabs) => {
+  switch (tab) {
+    case PlayerModalTabs.ACTIONS:
+      return <DialogActionView />
+    case PlayerModalTabs.INFO:
+      return <DialogInfoView />
+    case PlayerModalTabs.IDENTIFIERS:
+      return <DialogIdView />
+    case PlayerModalTabs.HISTORY:
+      return <DialogHistoryView />
+    case PlayerModalTabs.BAN:
+      return <DialogBanView />
+  }
+}
 
 export const DialogBaseView: React.FC = () => {
-  const { tab } = usePlayerModalContext();
+  const curTab = usePlayerModalTabValue()
 
   return (
     <Box flexGrow={1} mt={-2} overflow="hidden">
-      {tab == 1 && <DialogActionView />}
-      {tab == 2 && <DialogInfoView />}
-      {tab == 3 && <DialogIdView />}
-      {tab == 4 && <DialogHistoryView />}
-      {tab == 5 && <DialogBanView />}
+      {tabToRender(curTab)}
     </Box>
   );
 };

--- a/nui/src/components/PlayerModal/Tabs/DialogHistoryView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogHistoryView.tsx
@@ -1,6 +1,9 @@
 import React from "react";
-import { Box, Button, styled, Theme, Typography, useTheme } from "@mui/material";
-import { useForcePlayerRefresh, usePlayerDetailsValue } from "../../../state/playerDetails.state";
+import { Box, Typography, useTheme } from "@mui/material";
+import {
+  useForcePlayerRefresh,
+  usePlayerDetailsValue,
+} from "../../../state/playerDetails.state";
 import { useTranslate } from "react-polyglot";
 import { DialogLoadError } from "./DialogLoadError";
 import { PlayerHistoryItem } from "@shared/playerApiTypes";
@@ -8,7 +11,7 @@ import { useSnackbar } from "notistack";
 import { fetchWebPipe } from "@nui/src/utils/fetchWebPipe";
 import { GenericApiError, GenericApiResp } from "@shared/genericApiTypes";
 import { ButtonXS } from "../../misc/ButtonXS";
-import { tsToLocaleDate, tsToLocaleDateTime } from "@nui/src/utils/miscUtils";
+import { tsToLocaleDateTime } from "@nui/src/utils/miscUtils";
 
 // TODO: Make the styling on this nicer
 const NoHistoryBox = () => (
@@ -23,116 +26,147 @@ const colors = {
   danger: "#c2293e",
   warning: "#f1c40f",
   dark: "gray",
-}
+};
 
 type ActionCardProps = {
-  action: PlayerHistoryItem,
-  permsDisableWarn: boolean,
-  permsDisableBan: boolean,
-  serverTime: number,
-  btnAction: Function,
-}
-const ActionCard: React.FC<ActionCardProps> = ({ action, permsDisableWarn, permsDisableBan, serverTime, btnAction }) => {
+  action: PlayerHistoryItem;
+  permsDisableWarn: boolean;
+  permsDisableBan: boolean;
+  serverTime: number;
+  btnAction: Function;
+};
+const ActionCard: React.FC<ActionCardProps> = ({
+  action,
+  permsDisableWarn,
+  permsDisableBan,
+  serverTime,
+  btnAction,
+}) => {
   const theme = useTheme();
   const t = useTranslate();
 
-  const revokeButonDisabled = (
+  const revokeButonDisabled =
     action.revokedBy !== undefined ||
-    (action.type == 'warn' && permsDisableWarn) ||
-    (action.type == 'ban' && permsDisableBan)
-  )
+    (action.type == "warn" && permsDisableWarn) ||
+    (action.type == "ban" && permsDisableBan);
 
   let footerNote, actionColor, actionMessage;
-  if (action.type == 'ban') {
+  if (action.type == "ban") {
     actionColor = colors.danger;
-    actionMessage = t("nui_menu.player_modal.history.banned_by", { author: action.author });
-  } else if (action.type == 'warn') {
+    actionMessage = t("nui_menu.player_modal.history.banned_by", {
+      author: action.author,
+    });
+  } else if (action.type == "warn") {
     actionColor = colors.warning;
-    actionMessage = t("nui_menu.player_modal.history.warned_by", { author: action.author });
+    actionMessage = t("nui_menu.player_modal.history.warned_by", {
+      author: action.author,
+    });
   }
   if (action.revokedBy) {
     actionColor = colors.dark;
-    footerNote = t("nui_menu.player_modal.history.revoked_by", { author: action.revokedBy });
+    footerNote = t("nui_menu.player_modal.history.revoked_by", {
+      author: action.revokedBy,
+    });
   }
-  if (typeof action.exp == 'number') {
-    const expirationDate = tsToLocaleDateTime(action.exp, 'medium');
-    footerNote = (action.exp < serverTime)
-      ? t("nui_menu.player_modal.history.expired_at", { date: expirationDate })
-      : t("nui_menu.player_modal.history.expires_at", { date: expirationDate });
+  if (typeof action.exp == "number") {
+    const expirationDate = tsToLocaleDateTime(action.exp, "medium");
+    footerNote =
+      action.exp < serverTime
+        ? t("nui_menu.player_modal.history.expired_at", {
+            date: expirationDate,
+          })
+        : t("nui_menu.player_modal.history.expires_at", {
+            date: expirationDate,
+          });
   }
 
-  return <Box
-    style={{
-      background: theme.palette.background.paper,
-      padding: '0.35rem 0.55rem',
-      marginBottom: '6px',
-      borderLeft: `solid 4px ${actionColor}`,
-    }}
-  >
-    <Box style={{ display: 'flex', width: '100%', justifyContent: 'space-between' }}>
-      <strong>
-        {actionMessage}
-      </strong>
-      <Typography
-        variant="caption"
-        sx={{
-          fontFamily: 'monospace',
-          fontWeight: 'bold',
-          color: theme.palette.text.secondary,
+  return (
+    <Box
+      style={{
+        background: theme.palette.background.paper,
+        padding: "0.35rem 0.55rem",
+        marginBottom: "6px",
+        borderLeft: `solid 4px ${actionColor}`,
+      }}
+    >
+      <Box
+        style={{
+          display: "flex",
+          width: "100%",
+          justifyContent: "space-between",
         }}
       >
-        ({action.id})
-        &nbsp;
-        {tsToLocaleDateTime(action.ts, 'medium')}
-        &nbsp;
-        <ButtonXS
-          color="secondary"
-          variant="outlined"
-          onClick={btnAction as any}
-          disabled={revokeButonDisabled}
+        <strong>{actionMessage}</strong>
+        <Typography
+          variant="caption"
+          sx={{
+            fontFamily: "monospace",
+            fontWeight: "bold",
+            color: theme.palette.text.secondary,
+          }}
         >
-          {t("nui_menu.player_modal.history.btn_revoke")}
-        </ButtonXS>
-      </Typography>
+          ({action.id}) &nbsp;
+          {tsToLocaleDateTime(action.ts, "medium")}
+          &nbsp;
+          <ButtonXS
+            color="secondary"
+            variant="outlined"
+            onClick={btnAction as any}
+            disabled={revokeButonDisabled}
+          >
+            {t("nui_menu.player_modal.history.btn_revoke")}
+          </ButtonXS>
+        </Typography>
+      </Box>
+      <span style={{ color: theme.palette.text.secondary }}>
+        {action.reason}
+      </span>
+      {footerNote && (
+        <small style={{ display: "block", paddingTop: "0.35em" }}>
+          {footerNote}
+        </small>
+      )}
     </Box>
-    <span style={{ color: theme.palette.text.secondary }}>{action.reason}</span>
-    {footerNote && <small style={{ display: 'block', paddingTop: '0.35em' }}>{footerNote}</small>}
-  </Box>
-}
+  );
+};
 
 const DialogHistoryView: React.FC = () => {
   const { enqueueSnackbar } = useSnackbar();
   const playerDetails = usePlayerDetailsValue();
   const forceRefresh = useForcePlayerRefresh();
   const t = useTranslate();
-  if ('error' in playerDetails) return (<DialogLoadError />);
+  if ("error" in playerDetails) return <DialogLoadError />;
 
   const meta = playerDetails.meta;
   //slice is required to clone the array
-  const playerActionHistory = playerDetails.player.actionHistory.slice().reverse();
+  const playerActionHistory = playerDetails.player.actionHistory
+    .slice()
+    .reverse();
 
   const handleRevoke = async (actionId: string) => {
     try {
-      const result = await fetchWebPipe<GenericApiResp>(`/database/revoke_action`, {
-        method: "POST",
-        data: { action_id: actionId },
-      });
-      if ('success' in result && result.success === true) {
+      const result = await fetchWebPipe<GenericApiResp>(
+        `/database/revoke_action`,
+        {
+          method: "POST",
+          data: { action_id: actionId },
+        }
+      );
+      if ("success" in result && result.success === true) {
         forceRefresh((val) => val + 1);
-        enqueueSnackbar(
-          t(`nui_menu.player_modal.history.revoked_success`),
-          { variant: 'success' }
-        );
+        enqueueSnackbar(t(`nui_menu.player_modal.history.revoked_success`), {
+          variant: "success",
+        });
       } else {
         enqueueSnackbar(
           (result as GenericApiError).error ?? t("nui_menu.misc.unknown_error"),
-          { variant: 'error' }
+          { variant: "error" }
         );
       }
     } catch (error) {
-      enqueueSnackbar((error as Error).message, { variant: 'error' });
+      enqueueSnackbar((error as Error).message, { variant: "error" });
     }
-  }
+  };
 
   return (
     <Box p={2} height="100%" display="flex" flexDirection="column">
@@ -143,14 +177,18 @@ const DialogHistoryView: React.FC = () => {
         {!playerActionHistory?.length ? (
           <NoHistoryBox />
         ) : (
-          playerActionHistory.map((action) => <ActionCard
-            key={action.id}
-            action={action}
-            permsDisableWarn={!meta.tmpPerms.warn}
-            permsDisableBan={!meta.tmpPerms.ban}
-            serverTime={meta.serverTime}
-            btnAction={() => { handleRevoke(action.id) }}
-          />)
+          playerActionHistory.map((action) => (
+            <ActionCard
+              key={action.id}
+              action={action}
+              permsDisableWarn={!meta.tmpPerms.warn}
+              permsDisableBan={!meta.tmpPerms.ban}
+              serverTime={meta.serverTime}
+              btnAction={() => {
+                handleRevoke(action.id);
+              }}
+            />
+          ))
         )}
       </Box>
     </Box>

--- a/nui/src/components/PlayerModal/Tabs/DialogInfoView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogInfoView.tsx
@@ -19,51 +19,53 @@ import { GenericApiError, GenericApiResp } from "@shared/genericApiTypes";
 import humanizeDuration, { Unit } from "humanize-duration";
 import { ButtonXS } from "../../misc/ButtonXS";
 import { tsToLocaleDate } from "@nui/src/utils/miscUtils";
-import { usePlayerModalContext } from "@nui/src/provider/PlayerModalProvider";
-
-
+import {
+  PlayerModalTabs,
+  useSetPlayerModalTab,
+} from "@nui/src/state/playerModal.state";
 
 const DialogInfoView: React.FC = () => {
   const [note, setNote] = useState("");
   const { enqueueSnackbar } = useSnackbar();
   const playerDetails = usePlayerDetailsValue();
   const forceRefresh = useForcePlayerRefresh();
-  const { setTab } = usePlayerModalContext();
+  const setTab = useSetPlayerModalTab();
   const t = useTranslate();
   const theme = useTheme();
-  if ('error' in playerDetails) return (<DialogLoadError />);
+  if ("error" in playerDetails) return <DialogLoadError />;
 
   const meta = playerDetails.meta;
   const player = playerDetails.player;
 
   //Prepare vars
-  const language = t('$meta.humanizer_language');
+  const language = t("$meta.humanizer_language");
   function minsToDuration(seconds: number) {
     return humanizeDuration(seconds * 60_000, {
       language,
       round: true,
-      units: ['d', 'h', 'm'] as Unit[],
+      units: ["d", "h", "m"] as Unit[],
     });
   }
-
 
   const handleSaveNote: FormEventHandler = async (e) => {
     e.preventDefault();
     try {
-      const result = await fetchWebPipe<GenericApiResp>(`/player/save_note?mutex=current&netid=${player.netid}`, {
-        method: "POST",
-        data: { note: note.trim() },
-      });
-      if ('success' in result && result.success === true) {
+      const result = await fetchWebPipe<GenericApiResp>(
+        `/player/save_note?mutex=current&netid=${player.netid}`,
+        {
+          method: "POST",
+          data: { note: note.trim() },
+        }
+      );
+      if ("success" in result && result.success === true) {
         forceRefresh((val) => val + 1);
-        enqueueSnackbar(
-          t(`nui_menu.player_modal.info.notes_changed`),
-          { variant: 'success' }
-        );
+        enqueueSnackbar(t(`nui_menu.player_modal.info.notes_changed`), {
+          variant: "success",
+        });
       } else {
         enqueueSnackbar(
           (result as GenericApiError).error ?? t("nui_menu.misc.unknown_error"),
-          { variant: 'error' }
+          { variant: "error" }
         );
       }
     } catch (e) {
@@ -72,41 +74,43 @@ const DialogInfoView: React.FC = () => {
   };
 
   useEffect(() => {
-    setNote(player.notes ?? '');
+    setNote(player.notes ?? "");
   }, [playerDetails]);
 
   //Whitelist button
   const btnChangeWhitelistStatus = async () => {
     try {
-      const result = await fetchWebPipe<GenericApiResp>(`/player/whitelist?mutex=current&netid=${player.netid}`, {
-        method: "POST",
-        data: { status: !player.tsWhitelisted },
-      });
-      if ('success' in result && result.success === true) {
+      const result = await fetchWebPipe<GenericApiResp>(
+        `/player/whitelist?mutex=current&netid=${player.netid}`,
+        {
+          method: "POST",
+          data: { status: !player.tsWhitelisted },
+        }
+      );
+      if ("success" in result && result.success === true) {
         forceRefresh((val) => val + 1);
-        enqueueSnackbar(
-          t(`nui_menu.player_modal.info.btn_wl_success`),
-          { variant: 'success' }
-        );
+        enqueueSnackbar(t(`nui_menu.player_modal.info.btn_wl_success`), {
+          variant: "success",
+        });
       } else {
         enqueueSnackbar(
           (result as GenericApiError).error ?? t("nui_menu.misc.unknown_error"),
-          { variant: 'error' }
+          { variant: "error" }
         );
       }
     } catch (error) {
-      enqueueSnackbar((error as Error).message, { variant: 'error' });
+      enqueueSnackbar((error as Error).message, { variant: "error" });
     }
-  }
+  };
 
   //Log stuff
   const counts = { ban: 0, warn: 0 };
   for (const action of player.actionHistory) {
     counts[action.type]++;
   }
-  const btnLogDetails = async () => {
-    setTab(4);
-  }
+  const btnLogDetails = () => {
+    setTab(PlayerModalTabs.HISTORY);
+  };
 
   return (
     <DialogContent>
@@ -116,47 +120,59 @@ const DialogInfoView: React.FC = () => {
       <Typography>
         {t("nui_menu.player_modal.info.session_time")}:{" "}
         <span style={{ color: theme.palette.text.secondary }}>
-          {player.sessionTime ? minsToDuration(player.sessionTime) : '--'}
+          {player.sessionTime ? minsToDuration(player.sessionTime) : "--"}
         </span>
       </Typography>
       <Typography>
-        {t("nui_menu.player_modal.info.play_time")}: {" "}
-        < span style={{ color: theme.palette.text.secondary }}>
-          {player.playTime ? minsToDuration(player.playTime) : '--'}
+        {t("nui_menu.player_modal.info.play_time")}:{" "}
+        <span style={{ color: theme.palette.text.secondary }}>
+          {player.playTime ? minsToDuration(player.playTime) : "--"}
         </span>
-      </Typography >
+      </Typography>
       <Typography>
         {t("nui_menu.player_modal.info.joined")}:{" "}
         <span style={{ color: theme.palette.text.secondary }}>
-          {player.tsJoined ? tsToLocaleDate(player.tsJoined) : '--'}
+          {player.tsJoined ? tsToLocaleDate(player.tsJoined) : "--"}
         </span>
       </Typography>
       <Typography>
         {t("nui_menu.player_modal.info.whitelisted_label")}:{" "}
         <span style={{ color: theme.palette.text.secondary }}>
-          {player.tsWhitelisted ? tsToLocaleDate(player.tsWhitelisted) : t("nui_menu.player_modal.info.whitelisted_notyet")}
+          {player.tsWhitelisted
+            ? tsToLocaleDate(player.tsWhitelisted)
+            : t("nui_menu.player_modal.info.whitelisted_notyet")}
         </span>{" "}
         <ButtonXS
-          color={player.tsWhitelisted ? 'error' : 'primary'}
+          color={player.tsWhitelisted ? "error" : "primary"}
           variant="outlined"
           onClick={btnChangeWhitelistStatus as any}
           disabled={!meta.tmpPerms.whitelist || !player.license}
         >
-          {player.tsWhitelisted ? t("nui_menu.player_modal.info.btn_wl_remove") : t("nui_menu.player_modal.info.btn_wl_add")}
+          {player.tsWhitelisted
+            ? t("nui_menu.player_modal.info.btn_wl_remove")
+            : t("nui_menu.player_modal.info.btn_wl_add")}
         </ButtonXS>
       </Typography>
       <Typography>
         {t("nui_menu.player_modal.info.log_label")}:{" "}
         <span style={{ color: theme.palette.text.secondary }}>
-          {!counts.ban && !counts.warn ? t("nui_menu.player_modal.info.log_empty") : <>
-            <span style={{ color: theme.palette.error.main }}>
-              {t("nui_menu.player_modal.info.log_ban_count", { smart_count: counts.ban })}
-            </span>
-            ,&nbsp;
-            <span style={{ color: theme.palette.warning.main }}>
-              {t("nui_menu.player_modal.info.log_warn_count", { smart_count: counts.warn })}
-            </span>
-          </>}
+          {!counts.ban && !counts.warn ? (
+            t("nui_menu.player_modal.info.log_empty")
+          ) : (
+            <>
+              <span style={{ color: theme.palette.error.main }}>
+                {t("nui_menu.player_modal.info.log_ban_count", {
+                  smart_count: counts.ban,
+                })}
+              </span>
+              ,&nbsp;
+              <span style={{ color: theme.palette.warning.main }}>
+                {t("nui_menu.player_modal.info.log_warn_count", {
+                  smart_count: counts.warn,
+                })}
+              </span>
+            </>
+          )}
         </span>{" "}
         <ButtonXS
           color="secondary"
@@ -192,9 +208,7 @@ const DialogInfoView: React.FC = () => {
           </Button>
         </Box>
       </form>
-
-
-    </DialogContent >
+    </DialogContent>
   );
 };
 

--- a/nui/src/components/PlayersPage/PlayerCard.tsx
+++ b/nui/src/components/PlayersPage/PlayerCard.tsx
@@ -1,12 +1,6 @@
 import React, { memo } from "react";
-import { styled } from '@mui/material/styles';
-import {
-  Box,
-  Paper,
-  Theme,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { styled } from "@mui/material/styles";
+import { Box, Paper, Theme, Tooltip, Typography } from "@mui/material";
 import {
   DirectionsBoat,
   DirectionsWalk,
@@ -15,20 +9,20 @@ import {
   TwoWheeler,
   Flight,
 } from "@mui/icons-material";
-import { usePlayerModalContext } from "../../provider/PlayerModalProvider";
 import { useSetAssociatedPlayer } from "../../state/playerDetails.state";
 import { formatDistance } from "../../utils/miscUtils";
 import { useTranslate } from "react-polyglot";
 import { PlayerData, VehicleStatus } from "../../hooks/usePlayerListListener";
+import { useSetPlayerModalVisibility } from "@nui/src/state/playerModal.state";
 
-const PREFIX = 'PlayerCard';
+const PREFIX = "PlayerCard";
 
 const classes = {
   paper: `${PREFIX}-paper`,
   barBackground: `${PREFIX}-barBackground`,
   barInner: `${PREFIX}-barInner`,
   icon: `${PREFIX}-icon`,
-  tooltipOverride: `${PREFIX}-tooltipOverride`
+  tooltipOverride: `${PREFIX}-tooltipOverride`,
 };
 
 const StyledBox = styled(Box)(({ theme }) => ({
@@ -60,7 +54,7 @@ const StyledBox = styled(Box)(({ theme }) => ({
 
   [`& .${classes.tooltipOverride}`]: {
     fontSize: 12,
-  }
+  },
 }));
 
 const determineHealthBGColor = (val: number) => {
@@ -94,8 +88,7 @@ const HealthBar = styled(Box, {
 }));
 
 const PlayerCard: React.FC<{ playerData: PlayerData }> = ({ playerData }) => {
-
-  const { setModalOpen } = usePlayerModalContext();
+  const setModalOpen = useSetPlayerModalVisibility();
   const setAssociatedPlayer = useSetAssociatedPlayer();
   const t = useTranslate();
 
@@ -109,8 +102,8 @@ const PlayerCard: React.FC<{ playerData: PlayerData }> = ({ playerData }) => {
   };
 
   const handlePlayerClick = () => {
-    setModalOpen(true);
     setAssociatedPlayer(playerData);
+    setModalOpen(true);
   };
 
   const upperCaseStatus =

--- a/nui/src/hooks/useHudListenersService.tsx
+++ b/nui/src/hooks/useHudListenersService.tsx
@@ -11,10 +11,10 @@ import {
   useSetPlayerFilter,
   useSetPlayersFilterIsTemp,
 } from "../state/players.state";
-import { usePlayerModalContext } from "../provider/PlayerModalProvider";
 import { useSetAssociatedPlayer } from "../state/playerDetails.state";
 import { txAdminMenuPage, useSetPage } from "../state/page.state";
 import { useAnnounceNotiPosValue } from "../state/server.state";
+import { useSetPlayerModalVisibility } from "@nui/src/state/playerModal.state";
 
 type SnackbarAlertSeverities = "success" | "error" | "warning" | "info";
 
@@ -66,13 +66,13 @@ export const useHudListenersService = () => {
   const t = useTranslate();
   const onlinePlayers = usePlayersState();
   const setAssocPlayer = useSetAssociatedPlayer();
-  const { setModalOpen } = usePlayerModalContext();
+  const setModalOpen = useSetPlayerModalVisibility();
   const setPlayerFilter = useSetPlayerFilter();
   const setPlayersFilterIsTemp = useSetPlayersFilterIsTemp();
   const setPage = useSetPage();
   const notiPos = useAnnounceNotiPosValue();
 
-  const snackFormat = (m) => (
+  const snackFormat = (m: string) => (
     <span style={{ whiteSpace: "pre-wrap" }}>{m}</span>
   );
 

--- a/nui/src/state/playerModal.state.ts
+++ b/nui/src/state/playerModal.state.ts
@@ -1,0 +1,35 @@
+import {
+  atom,
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+} from "recoil";
+
+export enum PlayerModalTabs {
+  ACTIONS,
+  INFO,
+  IDENTIFIERS,
+  HISTORY,
+  BAN,
+}
+
+const playerModalTabAtom = atom<PlayerModalTabs>({
+  key: "playerModalTab",
+  default: PlayerModalTabs.ACTIONS,
+});
+
+export const usePlayerModalTabValue = () => useRecoilValue(playerModalTabAtom);
+export const useSetPlayerModalTab = () => useSetRecoilState(playerModalTabAtom);
+export const usePlayerModalTab = () => useRecoilState(playerModalTabAtom);
+
+const modalVisibilityAtom = atom({
+  key: "playerModalVisibility",
+  default: false,
+});
+
+export const usePlayerModalVisbilityValue = () =>
+  useRecoilValue(modalVisibilityAtom);
+export const usePlayerModalVisibility = () =>
+  useRecoilState(modalVisibilityAtom);
+export const useSetPlayerModalVisibility = () =>
+  useSetRecoilState(modalVisibilityAtom);

--- a/nui/src/utils/registerDebugFunctions.ts
+++ b/nui/src/utils/registerDebugFunctions.ts
@@ -21,6 +21,14 @@ const MenuObject = {
       },
     ]);
   },
+  setPlayerModalTarget: (target: string) => {
+    debugData<string>([
+      {
+        action: "openPlayerModal",
+        data: target
+      }
+    ])
+  },
   startPlayerUpdateLoop: (ms = 30000) => {
     if (playerUpdateInterval) {
       clearTimeout(playerUpdateInterval);


### PR DESCRIPTION
More gracefully handle the loading process for the player modal, instead of through the global suspense fallback. This PR also refactors the provider to not hold any of modal state, instead opting to store it within Recoil.

Also includes some miscellaneous cleanup. See below for comparison with mocked loading times of 300ms

### Before

![brave_xm1J4RtP2L](https://user-images.githubusercontent.com/15652018/204102950-655212ca-4f9c-4697-b4af-5aa731e49e13.gif)

### After

![brave_KN0tr0NPfr](https://user-images.githubusercontent.com/15652018/204102973-66c95bf5-143b-4d9b-9e42-3a5dc7bf0a09.gif)
