### PR TITLE
Feature 725 - Add environment variable to skip printing IP banner

### DIFF
--- a/core/globalData.ts
+++ b/core/globalData.ts
@@ -129,6 +129,7 @@ const isDevMode = getConvarBool('txAdminDevMode');
 const verboseConvar = getConvarBool('txAdminVerbose');
 const debugPlayerlistGenerator = getConvarBool('txDebugPlayerlistGenerator');
 const debugExternalSource = getConvarString('txDebugExternalSource');
+const skipIpBanner = getConvarBool('txSkipIpBanner');
 
 
 /**
@@ -214,6 +215,7 @@ export const convars = Object.freeze({
     isDevMode,
     debugPlayerlistGenerator,
     debugExternalSource,
+    skipIpBanner,
     //Convars - zap dependant
     isZapHosting,
     forceInterface,

--- a/core/txAdmin.js
+++ b/core/txAdmin.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import slash from 'slash';
 
 import logger from '@core/extras/console';
-import { txEnv } from '@core/globalData';
+import { txEnv, convars } from '@core/globalData';
 
 import { printBanner } from '@core/extras/banner';
 import setupProfile from '@core/extras/setupProfile';
@@ -206,7 +206,7 @@ export default class TxAdmin {
         }
 
         //Once they all finish loading, the function below will print the banner
-        if (!process.env.SKIP_BANNER) {
+        if (!convars.skipIpBanner) {
             printBanner();
         }
 

--- a/core/txAdmin.js
+++ b/core/txAdmin.js
@@ -206,7 +206,9 @@ export default class TxAdmin {
         }
 
         //Once they all finish loading, the function below will print the banner
-        printBanner();
+        if (!process.env.SKIP_BANNER) {
+            printBanner();
+        }
 
         //Run Update Checker every 15 minutes
         updateChecker();


### PR DESCRIPTION
Fixes #725

Adds a simple check for an env var presence to skip/bypass the IP banner dumping to console.