### PR TITLE
Added mouseover text to command history buttons

### DIFF
--- a/web/main/console.ejs
+++ b/web/main/console.ejs
@@ -161,6 +161,7 @@
             node.appendChild(document.createTextNode(btnText));
             node.setAttribute('id', stringToDOMId(command));
             node.setAttribute('class', 'btn btn-outline-light btn-sm m-1');
+            node.setAttribute('title', command);
             node.onclick = (e) => {
                 input.value = command;
                 input.focus();


### PR DESCRIPTION
The mouseover text displays the whole command of each previously used command on hover, making it easier to identify longer-sliced commands and avoid mixing them up when trying to execute them on the console page.

![Preview](https://user-images.githubusercontent.com/28988586/223575385-afeb36e0-d97f-4616-8633-a96d6b6a87fd.png)
