### PR TITLE
Fixing noclip crashes

### DIFF
--- a/resource/menu/vendor/freecam/camera.lua
+++ b/resource/menu/vendor/freecam/camera.lua
@@ -4,6 +4,7 @@ local SetCamRot = SetCamRot
 local IsCamActive = IsCamActive
 local SetCamCoord = SetCamCoord
 local LoadInterior = LoadInterior
+local UnpinInterior = UnpinInterior
 local SetFocusArea = SetFocusArea
 local LockMinimapAngle = LockMinimapAngle
 local GetInteriorAtCoords = GetInteriorAtCoords
@@ -55,11 +56,26 @@ function GetFreecamPosition()
   return _internal_pos
 end
 
+local lastLoadedInterior = 0
+
 function SetFreecamPosition(x, y, z)
   local pos = vector3(x, y, z)
   local int = GetInteriorAtCoords(pos)
 
-  LoadInterior(int)
+  if lastLoadedInterior ~= int then
+
+    if int ~= 0 then
+      LoadInterior(int)
+    end
+
+    if lastLoadedInterior ~= 0 then
+      UnpinInterior(lastLoadedInterior)
+    end
+
+    lastLoadedInterior = int
+
+  end
+  
   SetFocusArea(pos)
   LockMinimapPosition(x, y)
   SetCamCoord(_internal_camera, pos)


### PR DESCRIPTION
If you noclip for about 5 minutes full speed, it will crash your game, because the noclip loads a lot of interiors every frame and not releasing them. ending up with this crash: https://i.imgur.com/SaHSiqY.png
or the same with size 400.

This solution releases the interior once you get out of it.