### PR TITLE
Spawn blimp crash

### DIFF
--- a/resource/menu/client/cl_main_page.lua
+++ b/resource/menu/client/cl_main_page.lua
@@ -83,13 +83,20 @@ RegisterNUICallback('spawnVehicle', function(data, cb)
             [21] = "train",
         }
         local modelType = types[VehicleType] or "automobile"
-        if model == "submersible" or model == "submersible2" then
-            modelType = "submarine"
-        end
+      
+        local badTypes = {
+            ["submersible"] = "submarine",
+            ["submersible2"] = "submarine",
+            ["blimp"] = "heli",
+            ["blimp2"] = "heli",
+            ["blimp3"] = "heli"
+        }
 
-        if model == "blimp" or model == "blimp2" or model == "blimp3" then
-            modelType = "heli"
+        if badTypes[model] then
+            debugPrint("Model ".. model.." is included as a bad typed model, setting it from "..modelType.. " to "..badTypes[model])
+            modelType = badTypes[model]
         end
+    
             
         -- collect the old velocity
         local ped = PlayerPedId()

--- a/resource/menu/client/cl_main_page.lua
+++ b/resource/menu/client/cl_main_page.lua
@@ -83,12 +83,12 @@ RegisterNUICallback('spawnVehicle', function(data, cb)
             [21] = "train",
         }
         local modelType = types[VehicleType] or "automobile"
-        if model == GetHashKey("submersible") or model == GetHashKey("submersible2") then
+        if model == "submersible" or model == "submersible2" then
             modelType = "submarine"
         end
-            
-        if model == GetHashKey("blimp") then
-            modelType = "heli"        
+
+        if model == "blimp" or model == "blimp2" or model == "blimp3" then
+            modelType = "heli"
         end
             
         -- collect the old velocity

--- a/resource/menu/client/cl_main_page.lua
+++ b/resource/menu/client/cl_main_page.lua
@@ -86,6 +86,11 @@ RegisterNUICallback('spawnVehicle', function(data, cb)
         if model == GetHashKey("submersible") or model == GetHashKey("submersible2") then
             modelType = "submarine"
         end
+            
+        if model == GetHashKey("blimp") then
+            modelType = "heli"        
+        end
+            
         -- collect the old velocity
         local ped = PlayerPedId()
         local oldVeh = GetVehiclePedIsIn(ped, false)


### PR DESCRIPTION
When spawning a blimp it creates it with server setter "plane" instead of "heli" This is caused because somehow `GetVehicleClassFromName()` for blimp return plane type instead of heli, even though if you check it in the network object viewer (on normal blimps created by `CreateVehicle()`) - it will say its a heli.

I see that the _solution_ for that issue for models such as `submersible` and `submersible2` is setting it specifically hardcoded, so I just added this model as well with the same solution.