### PR TITLE
fix(client): super jump

### DIFF
--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -48,7 +48,7 @@
         - [x] scaleform/prompt
     - [x] god mode
     - [x] super jump
-        - [ ] fix stamina bug
+        - [x] fix stamina bug
     - [x] normal
     - [x] particles
 - [ ] Teleport

--- a/resource/menu/client/cl_player_mode.lua
+++ b/resource/menu/client/cl_player_mode.lua
@@ -16,36 +16,21 @@ local function toggleSuperJump(enabled)
         CreateThread(function()
             local Wait = Wait
             local pid = PlayerId()
-            if IS_FIVEM then
-                SetRunSprintMultiplierForPlayer(pid, 1.49)
-            else
-                --FIXME: this works, but i cannot revert it to the correct value, therefore better disable it
-                -- Citizen.InvokeNative(0xBBADFB5E5E5766FB, pid, 0.0) -- SetPlayerStaminaSprintDepletionMultiplier
-            end
-
             -- loop to keep player fast
             local frameCounter = 0
             while superJumpEnabled do
+                local ped = PlayerPedId()
                 frameCounter = frameCounter + 1
-                if frameCounter > 250 then
-                    if IS_FIVEM then
-                        RestorePlayerStamina(pid, 100.0)
-                    else
-                        -- Citizen.InvokeNative(0x675680D089BFA21F, ped, 100.0) -- RestorePedStamina
-                    end
+                if frameCounter > 200 then
+                    RestorePlayerStamina(pid, 100.0)
                     frameCounter = 0
                 end
+                SetPedMoveRateOverride(ped, 1.75)
                 SetSuperJumpThisFrame(pid)
                 Wait(0)
             end
-          end)
+        end)
     else
-        if IS_FIVEM then
-            local pid = PlayerId()
-            SetRunSprintMultiplierForPlayer(pid, 1.0)
-        else
-            -- Citizen.InvokeNative(0xBBADFB5E5E5766FB, pid, -1.0) -- SetPlayerStaminaSprintDepletionMultiplier
-        end
         clearPersistentAlert('superJumpEnabled')
     end
 end

--- a/resource/menu/client/cl_player_mode.lua
+++ b/resource/menu/client/cl_player_mode.lua
@@ -8,7 +8,7 @@ if not TX_MENU_ENABLED then return end
 
 local noClipEnabled = false
 local superJumpEnabled = false
-
+local moveRateOverride = IS_FIVEM and 1.75 or 1.15
 local function toggleSuperJump(enabled)
     superJumpEnabled = enabled
     if enabled then
@@ -16,16 +16,17 @@ local function toggleSuperJump(enabled)
         CreateThread(function()
             local Wait = Wait
             local pid = PlayerId()
+            local ped = PlayerPedId()
             -- loop to keep player fast
             local frameCounter = 0
             while superJumpEnabled do
-                local ped = PlayerPedId()
                 frameCounter = frameCounter + 1
                 if frameCounter > 200 then
                     RestorePlayerStamina(pid, 100.0)
+                    ped = PlayerPedId()
                     frameCounter = 0
                 end
-                SetPedMoveRateOverride(ped, 1.75)
+                SetPedMoveRateOverride(ped, moveRateOverride)
                 SetSuperJumpThisFrame(pid)
                 Wait(0)
             end


### PR DESCRIPTION
Still kind of confused on the stamina bug part since this 100% works on both FiveM and RedM. Since all natives used needs to be ran on each frame there is no need to disable them. This means we could also put `clearPersistentAlert` behind the while loop so it automatically gets ran when it gets disabled.

`SetPedMoveRateOverride` only gets set at 1.75 max in decompiled scripts in both FiveM and RedM. Unsure where the 10.0 comes from. Definitely works in FiveM though but seems to be some kind of placebo affect in RedM? Otherwise might need to test with `Citizen.Invoke`.

Get the player ped every frame in the odd chance the ped changes because of death etc👍🏼.