### PR TITLE
Fix for 0 hour ban expiration display bug

### DIFF
--- a/core/webroutes/player/checkJoin.ts
+++ b/core/webroutes/player/checkJoin.ts
@@ -191,6 +191,7 @@ function checkBan(
         if (ban.expiration) {
             const humanizeOptions = {
                 language,
+                largest: 2,
                 round: true,
                 units: ['d', 'h', 'm'] as Unit[],
             };

--- a/core/webroutes/player/checkJoin.ts
+++ b/core/webroutes/player/checkJoin.ts
@@ -192,7 +192,7 @@ function checkBan(
             const humanizeOptions = {
                 language,
                 round: true,
-                units: ['d', 'h'] as Unit[],
+                units: ['d', 'h', 'm'] as Unit[],
             };
             const duration = humanizeDuration((ban.expiration - ts) * 1000, humanizeOptions);
             expLine = `<strong>${textKeys.label_expiration}:</strong> ${duration} <br>`;


### PR DESCRIPTION
Players have been asking about a discrepancy where the ban duration displayed as 0 hours. To solve this, I've added a minute unit. The issue came up when the ban was set to be revoked within an hour.

Before:
<img width="285" alt="image" src="https://github.com/tabarra/txAdmin/assets/28988586/314c4e9e-7138-4c11-a43c-02372b848013">

After:
<img width="285" alt="image" src="https://github.com/tabarra/txAdmin/assets/28988586/3f394321-c68f-4af9-8e6c-901c0f1f9971">
