### PR TITLE
fix: dynamically create prompt title 

### DIFF
--- a/resource/menu/client/cl_spectate.lua
+++ b/resource/menu/client/cl_spectate.lua
@@ -185,10 +185,12 @@ local keysTable = {
 }
 
 local redmInstructionGroup, redmPromptTitle
-if IS_REDM then
-    redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'Spectate')
-    redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
-end
+RegisterNetEvent('txcl:spectate:start', function()
+    if IS_REDM then
+        redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'Spectate')
+        redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
+    end
+end)
 
 --- Key press checking (fivem)
 local function fivemCheckControls()

--- a/resource/menu/client/cl_spectate.lua
+++ b/resource/menu/client/cl_spectate.lua
@@ -183,14 +183,7 @@ local keysTable = {
     {'Previous Player', CONTROLS.prev},
     {'Next Player', CONTROLS.next},
 }
-
 local redmInstructionGroup, redmPromptTitle
-RegisterNetEvent('txcl:spectate:start', function()
-    if IS_REDM then
-        redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'Spectate')
-        redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
-    end
-end)
 
 --- Key press checking (fivem)
 local function fivemCheckControls()
@@ -271,6 +264,11 @@ end)
 
 -- Client-side event handler for an authorized spectate request
 RegisterNetEvent('txcl:spectate:start', function(targetServerId, targetCoords)
+    if IS_REDM then
+        redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'Spectate')
+        redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
+    end
+
     if isInTransitionState then
         stopSpectating()
         error('Spectate request received while in transition state')

--- a/resource/menu/vendor/freecam/main.lua
+++ b/resource/menu/vendor/freecam/main.lua
@@ -80,15 +80,13 @@ local keysTable = {
   {'Fwd/Back', CONTROLS.MOVE_Y},
 }
 local redmInstructionGroup, redmPromptTitle
-RegisterNetEvent('txcl:setPlayerMode', function(mode)
-  if mode == 'noclip' and IS_REDM then
-      redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'NoClip')
-      redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
-  end
-end)
 
 
 function StartFreecamThread()
+  if IS_REDM then
+    redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'NoClip')
+    redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
+  end
   -- Camera/Pos updating thread
   Citizen.CreateThread(function()
     local ped = PlayerPedId()

--- a/resource/menu/vendor/freecam/main.lua
+++ b/resource/menu/vendor/freecam/main.lua
@@ -80,10 +80,12 @@ local keysTable = {
   {'Fwd/Back', CONTROLS.MOVE_Y},
 }
 local redmInstructionGroup, redmPromptTitle
-if IS_REDM then
-  redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'NoClip')
-  redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
-end
+RegisterNetEvent('txcl:setPlayerMode', function(mode)
+  if mode == 'noclip' and IS_REDM then
+      redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'NoClip')
+      redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
+  end
+end)
 
 
 function StartFreecamThread()


### PR DESCRIPTION
For some reason whenever an UI element showed text (in this case the settings menu), it would overwrite the variable `redmPromptTitle`. Don't know how this hasn't been picked up by anyone else or maybe this is a problem on my end? Since I created the code myself this might as well simply be my lack of understanding core RDR behaviour (development wise).

I've added the `txcl:setPlayerMode` event to listen if noclip is being fired and recreate the title string when so. Theoretically speaking no performance downside. Same goes for spectate. Those are the only 2 functionalities using prompt titles.

<details><summary>Example images of the error</summary>
<p>

![image](https://github.com/tabarra/txAdmin/assets/44729807/8ea71b34-b219-43a0-afce-9b03d237a817)
![image](https://github.com/tabarra/txAdmin/assets/44729807/787e6770-ebc0-489b-8d47-5f816b03547a)

</p>
</details>

After the PR it should go back to 
![image](https://github.com/tabarra/txAdmin/assets/44729807/3366afcf-eb4c-4bec-8215-0f383034f428)
