### PR TITLE
tweak(resource/sv_admins): add sv_lan as a reason for Auth failure

### DIFF
--- a/resource/sv_admins.lua
+++ b/resource/sv_admins.lua
@@ -18,7 +18,6 @@ end
 -- Variables & Consts
 local failedAuths = {}
 local attemptCooldown = 15000
-local isLan = GetConvarInt("sv_lan", 0) == 1
 
 -- Handle auth failures
 local function handleAuthFail(src, reason)
@@ -39,7 +38,8 @@ RegisterNetEvent('txsv:checkIfAdmin', function()
     local src = source
     local srcString = tostring(source)
     debugPrint('Handling authentication request from player #'..srcString)
-
+    
+    local isLan = GetConvarInt("sv_lan", 0) == 1
     if isLan then
         return handleAuthFail(source, "sv_lan is enabled, please remove it from your server.cfg")
     end

--- a/resource/sv_admins.lua
+++ b/resource/sv_admins.lua
@@ -18,7 +18,7 @@ end
 -- Variables & Consts
 local failedAuths = {}
 local attemptCooldown = 15000
-
+local isLan = GetConvarInt("sv_lan", 0) == 1
 
 -- Handle auth failures
 local function handleAuthFail(src, reason)
@@ -40,6 +40,10 @@ RegisterNetEvent('txsv:checkIfAdmin', function()
     local srcString = tostring(source)
     debugPrint('Handling authentication request from player #'..srcString)
 
+    if isLan then
+        return handleAuthFail(source, "sv_lan is enabled, please remove it from your server.cfg")
+    end
+    
     -- Rate Limiter
     if type(failedAuths[srcString]) == 'number' and failedAuths[srcString] + attemptCooldown > GetGameTimer() then
         return handleAuthFail(source, "too many auth attempts")


### PR DESCRIPTION
Currently, having `sv_lan` enabled, will give you a "unknown" reason for txMenu auth failure, this PR simply checks for sv_lan and gives a reason for it :)