### PR TITLE
Update fxsConfigHelper.ts

### DIFF
--- a/core/extras/fxsConfigHelper.ts
+++ b/core/extras/fxsConfigHelper.ts
@@ -458,7 +458,7 @@ const validateCommands = async (parsedCommands: (ExecRecursionError | Command)[]
                 );
                 continue;
             }
-            if (convars.forceInterface && iface !== convars.forceInterface) {
+            if (convars.isZapHosting && convars.forceInterface && iface !== convars.forceInterface) {
                 errors.add(
                     cmd.file,
                     cmd.line,


### PR DESCRIPTION
Fixed conditional that checks if the interface to bind for the FXServer is the same as for txAdmin, which is only mandatory in the case of Zap Hosting because environment requirements. In other scenarios it may make sense that txAdmin binds to a different interface than FXServer does.