### PR TITLE
[BUG FIX] Server log in web panel will now reconnect when entering live mode

### DIFF
--- a/web/main/serverLog.ejs
+++ b/web/main/serverLog.ejs
@@ -239,7 +239,19 @@
 
             if (targetEl.classList.contains('collapse')) targetEl.classList.remove('collapse');
         })
-        
+
+        //============================================== Socket Stuff
+        pageSocket.on('error', (error) => {
+            console.log('Page Socket.IO', error)
+        });
+        pageSocket.on('connect', () => {
+            console.log("Page Socket.IO Connected.");
+            logContainer.innerHTML = '';
+        });
+        pageSocket.on('disconnect', (message) => {
+            console.log("Page Socket.IO Disonnected:", message);
+        });
+        pageSocket.on('logData', processLog);
 
         //============================================== Mode selection
         function goLive() {
@@ -248,20 +260,8 @@
             modeLabel.classList.add('text-success');
             modeLabel.textContent = 'LIVE';
             viewOlderBtn.disabled = false;
-            viewNewerBtn.disabled = true;
-
-            //Socket stuff
-            pageSocket.on('error', (error) => {
-                console.log('Page Socket.IO', error)
-            });
-            pageSocket.on('connect', () => {
-                console.log("Page Socket.IO Connected.");
-                logContainer.innerHTML = '';
-            });
-            pageSocket.on('disconnect', (message) => {
-                console.log("Page Socket.IO Disonnected:", message);
-            });
-            pageSocket.on('logData', processLog);
+            viewNewerBtn.disabled = true;            
+            if (!pageSocket.connected) pageSocket.connect();
         }
 
         function goHistory(direction) {


### PR DESCRIPTION
Resolves bug report: #921 

The socket was disconnected once checking out previous logs, but was never reconnected upon entering live mode again.
I also moved the event listeners outside the `goLive` function since it would add duplicate listeners on logData.

https://github.com/tabarra/txAdmin/assets/19311856/9affe260-1599-4500-bc87-e378362772ce