### PR TITLE
[BUG] RedM fails to authenticate when attempting to assign menu keybinds.

### DIFF
--- a/resource/menu/client/cl_base.lua
+++ b/resource/menu/client/cl_base.lua
@@ -97,11 +97,15 @@ RegisterNetEvent('txcl:setAdmin', function(username, perms, rejectReason)
     debugPrint("^2[AUTH] logged in as '" .. username .. "' with perms: " .. json.encode(perms or "nil"))
     menuIsAccessible = true
     menuPermissions = perms
-    RegisterKeyMapping('txadmin', 'Menu: Open Main Page', 'keyboard', '')
-    RegisterKeyMapping('txAdmin:menu:openPlayersPage', 'Menu: Open Players page', 'KEYBOARD', '')
-    RegisterKeyMapping('txAdmin:menu:noClipToggle', 'Menu: Toggle NoClip', 'keyboard', '')
-    RegisterKeyMapping('txAdmin:menu:togglePlayerIDs', 'Menu: Toggle Player IDs', 'KEYBOARD', '')
-    RegisterKeyMapping('txAdmin:menu:tpToWaypoint', 'Menu: Teleport to Waypoint', 'KEYBOARD', '')
+    if IS_FIVEM then
+      RegisterKeyMapping('txadmin', 'Menu: Open Main Page', 'keyboard', '')
+      RegisterKeyMapping('txAdmin:menu:openPlayersPage', 'Menu: Open Players page', 'KEYBOARD', '')
+      RegisterKeyMapping('txAdmin:menu:noClipToggle', 'Menu: Toggle NoClip', 'keyboard', '')
+      RegisterKeyMapping('txAdmin:menu:togglePlayerIDs', 'Menu: Toggle Player IDs', 'KEYBOARD', '')
+      RegisterKeyMapping('txAdmin:menu:tpToWaypoint', 'Menu: Teleport to Waypoint', 'KEYBOARD', '')
+    elseif IS_REDM then
+      debugPrint("RedM doesn't support custom key bindings yet. To use the menu use the `/tx` command.");
+    end
   else
     noMenuReason = tostring(rejectReason)
     debugPrint("^3[AUTH] rejected (" .. noMenuReason .. ")")


### PR DESCRIPTION
When logging in to RedM the below error is displayed and sometimes this causes the menu authentication to fail.
![image](https://github.com/tabarra/txAdmin/assets/19311856/b0a44df3-783f-4ed9-bf8d-c5b97235bdcf)
![image](https://github.com/tabarra/txAdmin/assets/19311856/9ecfd9a6-bd75-45df-8061-c47c1b334a76)

Executing `/txAdmin-reauth` doesn't fix the problem either, since this will also attempt to assign the menu keybinds.

So i fixed this by adding a check if the menu is running in `FiveM` or `RedM`