### PR TITLE
(fix) Removes lipsu from player crashes page.

### DIFF
--- a/panel/src/pages/PlayerCrashesPage.tsx
+++ b/panel/src/pages/PlayerCrashesPage.tsx
@@ -16,7 +16,7 @@ function CrashReasonCard({ reason, count, totalCrashes }: { reason: string, coun
                 <span className="ml-1 ">({percentage}%)</span>
             </div>
             <p className="flex-1 text-sm ">
-                {reason} lipsu
+                {reason}
             </p>
         </div>
     )


### PR DESCRIPTION
Self explanatory, just removes lipsu from the crash page.