### PR TITLE
chore(resource/menu/client): Added keybind for vehicle fix menu function

### DIFF
--- a/resource/cl_main.lua
+++ b/resource/cl_main.lua
@@ -142,6 +142,7 @@ CreateThread(function()
         '/txAdmin:menu:openPlayersPage',
         '/txAdmin:menu:togglePlayerIDs',
         '/txAdmin:menu:tpToWaypoint',
+        '/txAdmin:menu:fixVehicle',
 
         --Convars
         '/txAdmin-version',

--- a/resource/menu/client/cl_base.lua
+++ b/resource/menu/client/cl_base.lua
@@ -103,6 +103,7 @@ RegisterNetEvent('txcl:setAdmin', function(username, perms, rejectReason)
         RegisterKeyMapping('txAdmin:menu:noClipToggle', 'Menu: Toggle NoClip', 'keyboard', '')
         RegisterKeyMapping('txAdmin:menu:togglePlayerIDs', 'Menu: Toggle Player IDs', 'KEYBOARD', '')
         RegisterKeyMapping('txAdmin:menu:tpToWaypoint', 'Menu: Teleport to Waypoint', 'KEYBOARD', '')
+        RegisterKeyMapping('txAdmin:menu:fixVehicle', 'Menu: Fix vehicle', 'KEYBOARD', '')
     end
   else
     noMenuReason = tostring(rejectReason)

--- a/resource/menu/client/cl_vehicle.lua
+++ b/resource/menu/client/cl_vehicle.lua
@@ -369,3 +369,14 @@ RegisterNetEvent('txcl:seatInVehicle', function(vehNetID, seat, oldVehVelocity)
         end
     end
 end)
+
+RegisterCommand('txAdmin:menu:fixVehicle', function()
+    local ped = PlayerPedId()
+    local veh = GetVehiclePedIsIn(ped, false)
+    if (veh == 0) and not IsPedOnMount(ped) then
+        return sendSnackbarMessage('error', 'nui_menu.page_main.vehicle.not_in_veh_error', true)
+    end
+
+    TriggerServerEvent('txsv:req:vehicle:fix')
+    sendSnackbarMessage('info', 'nui_menu.page_main.vehicle.fix.success', true)
+end)


### PR DESCRIPTION
In this PR I have added support to set a keybind in the FiveM keybind settings to fix/repair the vehicle you are currently in.