### PR TITLE
fix(panel): don't focus bg color on select dropdownmenu in desktopnavbar

### DIFF
--- a/panel/src/components/ui/navigation-menu.tsx
+++ b/panel/src/components/ui/navigation-menu.tsx
@@ -42,7 +42,8 @@ const NavigationMenuItem = NavigationMenuPrimitive.Item
 
 //NOTE: fixed styles
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus:bg-secondary focus:text-secondary-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-secondary/50 data-[state=open]:bg-secondary/50"
+  // removed "focus:bg-secondary" with causing issues while selecting dropdown menu on a different page.
+  "group inline-flex h-10 w-max items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus:text-secondary-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-secondary/50 data-[state=open]:bg-secondary/50"
 )
 
 const NavigationMenuTrigger = React.forwardRef<


### PR DESCRIPTION
If you click on the dropdownmenu and move your mouse away of the dropdownmenu the focus is still activated on the button, this means you can have 2 buttons with the focus attribute in the desktopnavbar.

Example:
![image](https://github.com/user-attachments/assets/ba230c08-e3ba-4adb-be62-deac50cec909)

I couldn't find a way to disable the focus attribute for the specific button, but for now the 'NavigationMenuTrigger' is only used in the desktopnavbar, thats why I removed the full 'focus:bg-secondary'.
