### PR TITLE
Switch to game 'common' and remove rdr3_warning

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,7 +8,6 @@ repository 'https://github.com/tabarra/txAdmin'
 version 'REPLACE-VERSION'
 ui_label 'txAdmin'
 
-rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'
 fx_version 'cerulean'
 game 'common'
 -- nui_callback_strict_mode 'true' --FIXME: menu iframe doesn't work

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -10,7 +10,7 @@ ui_label 'txAdmin'
 
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'
 fx_version 'cerulean'
-games { 'gta5', 'rdr3' }
+game 'common'
 -- nui_callback_strict_mode 'true' --FIXME: menu iframe doesn't work
 -- lua54 'yes' --TODO: check if it works
 -- node_version '22'


### PR DESCRIPTION
This PR completes a TODO item from dev-notes.md under Chores + boring stuff (switch to `game 'common'` and remove `rdr3_warning`):

Switched to `game 'common'`
Removed `rdr3_warning`