### PR TITLE
fix(menu): disable weapon firing during noclip (#1061)

### DIFF
--- a/resource/menu/vendor/freecam/main.lua
+++ b/resource/menu/vendor/freecam/main.lua
@@ -90,6 +90,7 @@ function StartFreecamThread()
   -- Camera/Pos updating thread
   Citizen.CreateThread(function()
     local ped = PlayerPedId()
+    local playerId = PlayerId()
     local initialPos = GetEntityCoords(ped)
     SetFreecamPosition(initialPos[1], initialPos[2], initialPos[3])
     local veh = GetVehiclePedIsIn(ped, false)
@@ -113,6 +114,9 @@ function StartFreecamThread()
     local frameCounter = 0
     local loopPos, loopRotZ
     while IsFreecamActive() do
+      -- Disable weapon firing while in noclip (fixes #1061)
+      DisablePlayerFiring(playerId, true)
+
       loopPos, loopRotZ = UpdateCamera()
       frameCounter = frameCounter + 1
       if frameCounter > 100 then


### PR DESCRIPTION
## Summary
Fixes #1061 - Players can no longer fire weapons while in noclip mode.

## Problem
When a player activates noclip with a weapon equipped, they could still fire the weapon. This is unintended behavior for admin freecam mode.

## Solution
Added `DisablePlayerFiring(playerId, true)` inside the freecam loop in `resource/menu/vendor/freecam/main.lua`. Since the loop runs every frame (`Wait(0)`), this ensures firing stays disabled for the entire duration of noclip.

## Testing
1. Equip a weapon
2. Activate noclip via txAdmin menu
3. Try to fire → weapon should NOT fire
4. Disable noclip
5. Try to fire → weapon should fire normally

## Changes
- 1 file changed, 4 insertions(+)