### PR TITLE
fix(menu): prevent frozen players from bypassing freeze via vehicle spawn

### DIFF
--- a/resource/menu/client/cl_freeze.lua
+++ b/resource/menu/client/cl_freeze.lua
@@ -28,12 +28,31 @@ RegisterNetEvent('txcl:freezePlayerOk', function(isFrozen)
   sendSnackbarMessage('info', localeKey, true)
 end)
 
+local isFrozenFlag = false
+
 RegisterNetEvent('txcl:setFrozen', function(isFrozen)
   debugPrint('Frozen: ' .. tostring(isFrozen))
-  --NOTE: removed the check for vehicle, but could be done with 
-  -- IsPedInAnyVehicle for vehicles and IsPedOnMount for horses
   local playerPed = PlayerPedId()
   TaskLeaveAnyVehicle(playerPed, 0, 16)
   FreezeEntityPosition(playerPed, isFrozen)
   sendFreezeAlert(isFrozen)
+
+  if isFrozen and not isFrozenFlag then
+    isFrozenFlag = true
+    Citizen.CreateThread(function()
+      while isFrozenFlag do
+        local ped = PlayerPedId()
+        FreezeEntityPosition(ped, true)
+        DisableControlAction(0, 75, true) -- disable entering vehicles
+        local veh = GetVehiclePedIsIn(ped, false)
+        if veh ~= 0 then
+          FreezeEntityPosition(veh, true)
+          TaskLeaveAnyVehicle(ped, 0, 16)
+        end
+        Wait(0)
+      end
+    end)
+  elseif not isFrozen then
+    isFrozenFlag = false
+  end
 end)


### PR DESCRIPTION
## Summary
Fixes #1000 — Frozen players can no longer bypass freeze by spawning and entering a vehicle.

## Problem
The freeze handler called `FreezeEntityPosition` only once. If a frozen player spawned a vehicle (e.g. via a server menu) and entered it, the freeze was effectively lost since the vehicle itself wasn't frozen and the ped freeze could be overridden.

## Solution
Added a persistent thread that runs while the player is frozen:
- Continuously re-applies `FreezeEntityPosition` on the ped every frame
- Disables the "enter vehicle" control (control 75)
- If the player manages to enter a vehicle, freezes the vehicle and ejects them

The thread exits cleanly when the player is unfrozen.

## Testing
1. Freeze a player via txAdmin menu
2. Have the player spawn a vehicle (via any server menu/script)
3. Player should NOT be able to enter or drive the vehicle
4. Unfreeze the player
5. Player should be able to enter and drive vehicles normally