### PR TITLE
fix(panel): update broken Discord bot setup guide links

### DIFF
--- a/panel/src/pages/Settings/tabCards/discord.tsx
+++ b/panel/src/pages/Settings/tabCards/discord.tsx
@@ -125,7 +125,7 @@ export default function ConfigCardDiscord({ cardCtx, pageCtx }: SettingsCardProp
                 />
                 <SettingItemDesc>
                     To get a token and the bot to join your server, follow these two guides: <br />
-                    <TxAnchor  href="https://discordjs.guide/preparations/setting-up-a-bot-application.html">Setting up a bot application</TxAnchor> and <TxAnchor href="https://discordjs.guide/preparations/adding-your-bot-to-servers.html">Adding your bot to servers</TxAnchor> <br />
+                    <TxAnchor  href="https://discord.com/developers/docs/quick-start/getting-started">Setting up a bot application</TxAnchor> and <TxAnchor href="https://discord.com/developers/docs/topics/oauth2">Adding your bot to servers</TxAnchor> <br />
                     <strong>Note:</strong> Do not reuse the same token for another bot. <br />
                     <strong>Note:</strong> The bot requires the <strong>Server Members</strong> intent, which can be set at the <TxAnchor href="https://discord.com/developers/applications">Discord Developer Portal</TxAnchor>.
                 </SettingItemDesc>


### PR DESCRIPTION
## Summary
Fixes #1079 — Updates broken Discord bot setup links in the settings page.

## Problem
The two discordjs.guide URLs in the Discord settings tab now return 404:
- `discordjs.guide/preparations/setting-up-a-bot-application.html`
- `discordjs.guide/preparations/adding-your-bot-to-servers.html`

## Solution
Replaced with the official Discord developer documentation URLs:
- `discord.com/developers/docs/quick-start/getting-started` (bot setup)
- `discord.com/developers/docs/topics/oauth2` (adding bot to servers)

## Test plan
- [x] Both new URLs return 200
- [ ] Verify links render correctly in the Discord settings tab