### PR TITLE
fix(menu): handle spectate requests during transition state gracefully

### DIFF
--- a/resource/menu/client/cl_spectate.lua
+++ b/resource/menu/client/cl_spectate.lua
@@ -269,9 +269,17 @@ RegisterNetEvent('txcl:spectate:start', function(targetServerId, targetCoords)
         redmInstructionGroup = makeRedmInstructionalGroup(keysTable)
     end
 
+    -- Wait for any ongoing transition to complete before proceeding (#1084)
     if isInTransitionState then
-        stopSpectating()
-        error('Spectate request received while in transition state')
+        local attempts = 0
+        while isInTransitionState and attempts < 100 do
+            Wait(50)
+            attempts = attempts + 1
+        end
+        if isInTransitionState then
+            debugPrint('Spectate request timed out waiting for transition state')
+            return sendSnackbarMessage('error', 'nui_menu.player_modal.actions.interaction.notifications.spectate_failed', true)
+        end
     end
 
     -- check if self-spectate


### PR DESCRIPTION
## Summary
Fixes #1084 — Spectate no longer crashes with a script error when rapidly cycling through players.

## Problem
When quickly pressing up/down arrows to cycle spectated players, a new `txcl:spectate:start` event could arrive while the previous transition (screen fade, collision loading) was still in progress. The handler called `stopSpectating()` followed by `error()`, which produced:

```
SCRIPT ERROR: @monitor/resource/menu/client/cl_spectate.lua:274: Spectate request received while in transition state
```

This left the player with a black screen or broke spectate entirely.

## Solution
Instead of erroring immediately, the handler now waits up to 5 seconds (100 attempts x 50ms) for the ongoing transition to complete. If the transition finishes in time, the new spectate request proceeds normally. If it times out, a user-friendly snackbar error is shown instead of a script crash.

## Testing
1. Start spectating a player
2. Rapidly press up/down arrow keys to cycle through players
3. Spectate should transition smoothly without script errors or black screens
4. If a transition takes too long, a "spectate failed" message should appear instead of crashing